### PR TITLE
Processing pipeline for historical installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,17 @@ Replace the `...` above with
 
 To update the data on the `asf-core-data` S3 bucket, run:
 
+    export COMPANIES_HOUSE_API_KEY="ADD_YOUR_API_KEY_HERE"
+
     from asf_core_data import generate_and_save_mcs
 
-    generate_and_save_mcs(epc_data_path=...)
+    generate_and_save_mcs()
+
+which requires the user to have a Companies House API key:
+
+- Create a developer account for Companies House API[here](https://developer.company-information.service.gov.uk/get-started);
+- Create a new application [here](https://developer.company-information.service.gov.uk/manage-applications/add). Give it any name and description you want and choose the Live environment.
+  Copy your API key credentials.
 
 This requires processed EPC data to be saved locally as set out by the requirements in the section above.
 
@@ -241,10 +249,6 @@ To run checks on raw installations data:
     from asf_core_data import test_installation_data
 
     test_installation_data(filename)
-
-To produce a new processed version of installer data on S3, run `generate_and_save_mcs` as above, then using a Companies House API key run
-
-    python asf_core_data/pipeline/mcs/process/process_mcs_installers.py -key [API KEY]
 
 ### Installations <a name="mcs_installations"></a>
 
@@ -263,7 +267,6 @@ The MCS **installers** dataset contains one record for each MCS-certified instal
 
 - name and address
 - technologies installed
-- locations in which the installer operates
 
 ### Merging with EPC <a name="mcs_epc_merging"></a>
 

--- a/asf_core_data/analysis/historical_installers.ipynb
+++ b/asf_core_data/analysis/historical_installers.ipynb
@@ -1,0 +1,83 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notebook to compare raw to processed historical installers data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from asf_core_data.getters.mcs_getters.get_mcs_installers import get_raw_historical_mcs_installers, get_processed_historical_installers_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raw_data = get_raw_historical_mcs_installers(\"raw_historical_mcs_installers_20230207.xlsx\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raw_data.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "processed_data = get_processed_historical_installers_data(\"20230207\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "processed_data.head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.5 64-bit",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.5"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/asf_core_data/config/base_config.py
+++ b/asf_core_data/config/base_config.py
@@ -627,7 +627,7 @@ raw_historical_installations_dtypes = {
     "Installation Type": str,
 }
 
-
+MCS_HISTORICAL_DATA_OUTPUTS_PATH = "/outputs/MCS/installers/"
 PREPROCESSED_MCS_HISTORICAL_INSTALLERS_FILE_PATH = (
     "/outputs/MCS/installers/mcs_historical_installers_{}.csv"
 )

--- a/asf_core_data/config/base_config.py
+++ b/asf_core_data/config/base_config.py
@@ -1,4 +1,6 @@
 from asf_core_data import Path
+from datetime import datetime
+import numpy as np
 
 MCS_RAW_S3_PATH = "inputs/MCS/mcs_heat_pumps.xlsx"
 MCS_RAW_LOCAL_PATH = "/inputs/data/mcs/mcs_heat_pumps.xlsx"
@@ -545,11 +547,91 @@ RAW_DATA_S3_FOLDER = "inputs/MCS/latest_raw_data"
 
 
 # HISTORICAL INSTALLERS
-PREPROCESSED_MCS_HISTORICAL_INSTALLERS_PATH = (
+MCS_HISTORICAL_DATA_INPUTS_PATH = "inputs/MCS/latest_raw_data/historical/"
+raw_historical_installers_dtypes = {
+    "Company Name": str,
+    "MCS certificate number": int,
+    "Adddress 1": str,
+    "Adddress 2": str,
+    "Town": str,
+    "County": str,
+    "Postcode": str,
+    "Effective From": datetime,
+    "Effective To": datetime,
+    "Air Source Heat Pump Installation Start Date": datetime,
+    "Air Source Heat Pump Installation End Date": datetime,
+    "Air Source Heat Pump Design Start Date": datetime,
+    "Air Source Heat Pump Design End Date": datetime,
+    "Biomass Start Date": datetime,
+    "Biomass End Date": datetime,
+    "Ground/Water Source Heat Pump Installation Start Date": datetime,
+    "Ground/Water Source Heat Pump Installation End Date": datetime,
+    "Ground/Water Source Heat Pump Design Start Date": datetime,
+    "Ground/Water Source Heat Pump Design End Date": datetime,
+    "Hot Water Heat Pump Installation Start Date": datetime,
+    "Hot Water Heat Pump Installation End Date": datetime,
+    "Hot Water Heat Pump Design Start Date": datetime,
+    "Hot Water Heat Pump Design End Date": datetime,
+    "Hydro Start Date": datetime,
+    "Hydro End Date": datetime,
+    "Micro CHP Start Date": datetime,
+    "Micro CHP End Date": datetime,
+    "Solar PV Start Date": datetime,
+    "Solar PV End Date": datetime,
+    "Wind Turbine Start Date": datetime,
+    "Wind Turbine End Date": datetime,
+    "Exhaust Air Heat Pump Installation Start Date": datetime,
+    "Exhaust Air Heat Pump Installation End Date": datetime,
+    "Exhaust Air Heat Pump Design Start Date": datetime,
+    "Exhaust Air Heat Pump Design End Date": datetime,
+    "Gas Absorbtion Heat Pump Installation Start Date": datetime,
+    "Gas Absorbtion Heat Pump Installation End Date": datetime,
+    "Gas Absorbtion Heat Pump Design Start Date": datetime,
+    "Gas Absorbtion Heat Pump Design End Date": datetime,
+    "Solar Assisted Heat Pump Installation Start Date": datetime,
+    "Solar Assisted Heat Pump Installation End Date": datetime,
+    "Solar Assisted Heat Pump Design Start Date": datetime,
+    "Solar Assisted Heat Pump Design End Date": datetime,
+    "Solar Thermal Start Date": datetime,
+    "Solar Thermal End Date": datetime,
+    "Battery Storage Start Date": datetime,
+    "Battery Storage End Date": datetime,
+}
+
+raw_historical_installations_dtypes = {
+    "Version Number": int,
+    "Commissioning Date": datetime,
+    "Address Line 1": str,
+    "Address Line 2": str,
+    "Address Line 3": str,
+    "County": str,
+    "Postcode": str,
+    "Local Authority": str,
+    "Total Installed Capacity": float,
+    "Estimated Annual Generation": float,
+    "Green Deal Installation?": str,
+    "Installation Company Name": str,
+    "Installation Company MCS Number": str,
+    "Products": str,
+    "Technology Type": str,
+    "Installation New at Commissioning Date?": datetime,
+    "Renewable System Design": str,
+    "Annual Space Heating Demand": float,
+    "Annual Water Heating Demand": float,
+    "Annual Space Heating Supplied": float,
+    "Annual Water Heating Supplied": float,
+    "Number of MCS Certificates": float,
+    "Heating System Type": str,
+    "Fuel Type": str,
+    "Overall Cost": float,
+    "Installation Type": str,
+}
+
+
+PREPROCESSED_MCS_HISTORICAL_INSTALLERS_FILE_PATH = (
     "/outputs/MCS/installers/mcs_historical_installers_{}.csv"
 )
-
-historical_installers_columns_order = [
+processed_historical_installers_columns_order = [
     "company_unique_id",
     "company_name",
     "mcs_certificate_number",
@@ -604,4 +686,64 @@ historical_installers_columns_order = [
     "exhaust_air_hp_certified",
     "gas_absorbtion_hp_certified",
     "solar_assisted_hp_certified",
+]
+
+preprocessed_historical_installers_dtypes = {
+    "company_unique_id": str,
+    "company_name": str,
+    "mcs_certificate_number": int,
+    "certification_body": str,
+    "address_1": str,
+    "address_2": str,
+    "town": str,
+    "county": str,
+    "postcode": str,
+    "latitude": float,
+    "longitude": float,
+    "full_address": str,
+    "original_record": bool,
+    "biomass_certified": bool,
+    "hydro_certified": bool,
+    "micro_chp_certified": bool,
+    "solar_pv_certified": bool,
+    "wind_turbine_certified": bool,
+    "solar_thermal_certified": bool,
+    "battery_storage_certified": bool,
+    "air_source_hp_certified": bool,
+    "ground_water_source_hp_certified": bool,
+    "hot_water_hp_certified": bool,
+    "exhaust_air_hp_certified": bool,
+    "gas_absorbtion_hp_certified": bool,
+    "solar_assisted_hp_certified": bool,
+}
+
+preprocessed_historical_installers_date_cols = [
+    "effective_from",
+    "effective_to",
+    "biomass_start_date",
+    "biomass_end_date",
+    "hydro_start_date",
+    "hydro_end_date",
+    "micro_chp_start_date",
+    "micro_chp_end_date",
+    "solar_pv_start_date",
+    "solar_pv_end_date",
+    "wind_turbine_start_date",
+    "wind_turbine_end_date",
+    "solar_thermal_start_date",
+    "solar_thermal_end_date",
+    "battery_storage_start_date",
+    "battery_storage_end_date",
+    "air_source_hp_start_date",
+    "air_source_hp_end_date",
+    "ground_water_source_hp_start_date",
+    "ground_water_source_hp_end_date",
+    "hot_water_hp_start_date",
+    "hot_water_hp_end_date",
+    "exhaust_air_hp_start_date",
+    "exhaust_air_hp_end_date",
+    "gas_absorbtion_hp_start_date",
+    "gas_absorbtion_hp_end_date",
+    "solar_assisted_hp_start_date",
+    "solar_assisted_hp_end_date",
 ]

--- a/asf_core_data/config/base_config.py
+++ b/asf_core_data/config/base_config.py
@@ -542,3 +542,66 @@ S3_NEW_MCS_DATA_DUMP_DIR = "inputs/MCS/latest_raw_data/"
 INSTALLATIONS_RAW_S3_PATH = "inputs/MCS/mcs_installations.csv"
 INSTALLATIONS_RAW_LOCAL_PATH = "/inputs/data/mcs/installations"
 RAW_DATA_S3_FOLDER = "inputs/MCS/latest_raw_data"
+
+
+# HISTORICAL INSTALLERS
+PREPROCESSED_MCS_HISTORICAL_INSTALLERS_PATH = (
+    "/outputs/MCS/installers/mcs_historical_installers_{}.csv"
+)
+
+historical_installers_columns_order = [
+    "company_unique_id",
+    "company_name",
+    "mcs_certificate_number",
+    "certification_body",
+    "address_1",
+    "address_2",
+    "town",
+    "county",
+    "postcode",
+    "latitude",
+    "longitude",
+    "full_address",
+    "original_record",
+    "effective_from",
+    "effective_to",
+    "biomass_start_date",
+    "biomass_end_date",
+    "hydro_start_date",
+    "hydro_end_date",
+    "micro_chp_start_date",
+    "micro_chp_end_date",
+    "solar_pv_start_date",
+    "solar_pv_end_date",
+    "wind_turbine_start_date",
+    "wind_turbine_end_date",
+    "solar_thermal_start_date",
+    "solar_thermal_end_date",
+    "battery_storage_start_date",
+    "battery_storage_end_date",
+    "air_source_hp_start_date",
+    "air_source_hp_end_date",
+    "ground_water_source_hp_start_date",
+    "ground_water_source_hp_end_date",
+    "hot_water_hp_start_date",
+    "hot_water_hp_end_date",
+    "exhaust_air_hp_start_date",
+    "exhaust_air_hp_end_date",
+    "gas_absorbtion_hp_start_date",
+    "gas_absorbtion_hp_end_date",
+    "solar_assisted_hp_start_date",
+    "solar_assisted_hp_end_date",
+    "biomass_certified",
+    "hydro_certified",
+    "micro_chp_certified",
+    "solar_pv_certified",
+    "wind_turbine_certified",
+    "solar_thermal_certified",
+    "battery_storage_certified",
+    "air_source_hp_certified",
+    "ground_water_source_hp_certified",
+    "hot_water_hp_certified",
+    "exhaust_air_hp_certified",
+    "gas_absorbtion_hp_certified",
+    "solar_assisted_hp_certified",
+]

--- a/asf_core_data/config/base_config.py
+++ b/asf_core_data/config/base_config.py
@@ -545,6 +545,45 @@ INSTALLATIONS_RAW_S3_PATH = "inputs/MCS/mcs_installations.csv"
 INSTALLATIONS_RAW_LOCAL_PATH = "/inputs/data/mcs/installations"
 RAW_DATA_S3_FOLDER = "inputs/MCS/latest_raw_data"
 
+# HISTORICAL INSTALLATIONS
+historical_installations_rename_cols_dict = {
+    "Version Number": "version",
+    "Certificate Creation Date": "cert_date",
+    "Commissioning Date": "commission_date",
+    "Address Line 1": "address_1",
+    "Address Line 2": "address_2",
+    "Address Line 3": "address_3",
+    "County": "county",
+    "Postcode": "postcode",
+    "Local Authority": "local_authority",
+    "Total Installed Capacity": "capacity",
+    "Estimated Annual Generation": "estimated_annual_generation",
+    "Installation Company Name": "installer_name",
+    "Green Deal Installation?": "green_deal",
+    "Products": "products",
+    "Flow temp/SCOP ": "flow_scop",
+    "Technology Type": "tech_type",
+    "Installation Type": "installation_type",
+    " Installation Type": "installation_type",
+    "End User Installation Type": "end_user_installation_type",
+    "Installation New at Commissioning Date?": "new",
+    "Renewable System Design": "design",
+    "Annual Space Heating Demand": "heat_demand",
+    "Annual Water Heating Demand": "water_demand",
+    "Annual Space Heating Supplied": "heat_supplied",
+    "Annual Water Heating Supplied": "water_supplied",
+    "Installation Requires Metering?": "metering",
+    "RHI Metering Status": "rhi_status",
+    "RHI Metering Not Ready Reason": "rhi_not_ready",
+    "Number of MCS Certificates": "n_certificates",
+    "Heating System Type": "system_type",
+    "Alternative Heating System Type": "alt_type",
+    "Alternative Heating System Fuel Type": "alt_fuel",
+    "Overall Cost": "cost",
+    "Fuel Type": "fuel_type",
+    "Installation Company MCS Number": "installation_company_mcs_number",
+}
+
 
 # HISTORICAL INSTALLERS
 MCS_HISTORICAL_DATA_INPUTS_PATH = "inputs/MCS/latest_raw_data/historical/"
@@ -627,7 +666,7 @@ raw_historical_installations_dtypes = {
     "Installation Type": str,
 }
 
-MCS_HISTORICAL_DATA_OUTPUTS_PATH = "/outputs/MCS/installers/"
+MCS_HISTORICAL_DATA_OUTPUTS_PATH = "outputs/MCS/installers/"
 PREPROCESSED_MCS_HISTORICAL_INSTALLERS_FILE_PATH = (
     "/outputs/MCS/installers/mcs_historical_installers_{}.csv"
 )

--- a/asf_core_data/getters/data_getters.py
+++ b/asf_core_data/getters/data_getters.py
@@ -25,16 +25,22 @@ def get_s3_dir_files(s3, bucket_name, dir_name):
     return dir_files
 
 
-def load_s3_data(bucket_name, file_name, usecols=None):
+def load_s3_data(
+    bucket_name, file_name, usecols=None, dtypes=None, columns_to_parse_as_dates=None
+):
     """
     Load data from S3 location.
     bucket_name: The S3 bucket name
     file_name: S3 key to load
     usecols: Columns of data to use. Defaults to None, loading all columns.
+    dtypes: data types
+    columns_to_parse_as_dates: columns that should be parsed as dates (when reading as csv)
     """
     if fnmatch(file_name, "*.xlsx"):
         data = pd.read_excel(
-            os.path.join("s3://" + bucket_name, file_name), sheet_name=None
+            os.path.join("s3://" + bucket_name, file_name),
+            sheet_name=None,
+            dtype=dtypes,
         )
         if len(data) > 1:
             return data
@@ -45,6 +51,8 @@ def load_s3_data(bucket_name, file_name, usecols=None):
             os.path.join("s3://" + bucket_name, file_name),
             encoding="latin-1",
             usecols=usecols,
+            dtype=dtypes,
+            parse_dates=columns_to_parse_as_dates,
         )
     elif fnmatch(file_name, "*.pickle") or fnmatch(file_name, "*.pkl"):
         obj = s3.Object(bucket_name, file_name)

--- a/asf_core_data/getters/data_getters.py
+++ b/asf_core_data/getters/data_getters.py
@@ -114,7 +114,6 @@ def get_most_recent_batch_name(
         The most recent batch.
     """
     batches = [key for key in get_s3_dir_files(s3, bucket, s3_folder_path)]
-    print(batches)
 
     final_set = []
     if filter_keep_keywords is None and filter_remove_keywords is None:

--- a/asf_core_data/getters/mcs_getters/get_mcs_installations.py
+++ b/asf_core_data/getters/mcs_getters/get_mcs_installations.py
@@ -72,17 +72,6 @@ def get_raw_installations_data(
     return hps
 
 
-def get_raw_mcs_installations_concatenated_files():
-    """
-    Get raw MCS installations concatenated files.
-    """
-    return load_s3_data(
-        bucket_name=base_config.BUCKET_NAME,
-        file_name="inputs/MCS/mcs_installations.csv",
-        columns_to_parse_as_dates=["commission_date"],
-    )
-
-
 def get_most_recent_raw_historical_installations_data() -> pd.DataFrame:
     """
     Get the most recent version of the raw historical heat pump MCS certified installation data from S3.

--- a/asf_core_data/getters/mcs_getters/get_mcs_installations.py
+++ b/asf_core_data/getters/mcs_getters/get_mcs_installations.py
@@ -70,3 +70,26 @@ def get_raw_installations_data(
         print("Shape of loaded data:", hps.shape)
 
     return hps
+
+
+def get_raw_historical_installations_data(
+    raw_historical_installations_file_name: str,
+) -> pd.DataFrame:
+    """
+    Get raw MCS historical installation data (both domestic and non-domestic)
+    for S3 bucket.
+
+    Args:
+        raw_historical_mcs_installations_file_name: name of file in S3 bucket, raw_historical_installations_YYYYMMDD.xlsx
+        where YYYY/MM/DD is the date MCS shared the file in the Data Dumps Google Drive folder.
+    Returns:
+        Raw historical installation data
+    """
+    return load_s3_data(
+        bucket_name=base_config.BUCKET_NAME,
+        file_name=os.path.join(
+            base_config.MCS_HISTORICAL_DATA_INPUTS_PATH,
+            raw_historical_installations_file_name,
+        ),
+        dtypes=base_config.raw_historical_installations_dtypes,
+    )

--- a/asf_core_data/getters/mcs_getters/get_mcs_installations.py
+++ b/asf_core_data/getters/mcs_getters/get_mcs_installations.py
@@ -7,7 +7,7 @@ with correct dtypes."""
 import pandas as pd
 import os
 
-from asf_core_data.getters.data_getters import load_s3_data
+from asf_core_data.getters.data_getters import load_s3_data, get_most_recent_batch_name
 
 from asf_core_data.config import base_config
 
@@ -72,11 +72,43 @@ def get_raw_installations_data(
     return hps
 
 
+def get_raw_mcs_installations_concatenated_files():
+    """
+    Get raw MCS installations concatenated files.
+    """
+    return load_s3_data(
+        bucket_name=base_config.BUCKET_NAME,
+        file_name="inputs/MCS/mcs_installations.csv",
+        columns_to_parse_as_dates=["commission_date"],
+    )
+
+
+def get_most_recent_raw_historical_installations_data() -> pd.DataFrame:
+    """
+    Get the most recent version of the raw historical heat pump MCS certified installation data from S3.
+
+    Returns:
+        The most recent version of the raw historical installations data from MCS.
+    """
+
+    bucket = base_config.BUCKET_NAME
+    path = base_config.MCS_HISTORICAL_DATA_INPUTS_PATH
+    most_recent_file_name = get_most_recent_batch_name(
+        bucket=bucket, s3_folder_path=path, filter_keep_keywords=["installation"]
+    )
+
+    return load_s3_data(
+        bucket_name=base_config.BUCKET_NAME,
+        file_name=most_recent_file_name,
+        dtypes=base_config.raw_historical_installations_dtypes,
+    )
+
+
 def get_raw_historical_installations_data(
     raw_historical_installations_file_name: str,
 ) -> pd.DataFrame:
     """
-    Get raw MCS historical installation data (both domestic and non-domestic)
+    Get a specified version of the raw MCS historical installation data (both domestic and non-domestic)
     for S3 bucket.
 
     Args:

--- a/asf_core_data/getters/mcs_getters/get_mcs_installers.py
+++ b/asf_core_data/getters/mcs_getters/get_mcs_installers.py
@@ -5,17 +5,37 @@ Functions to get MCS certified heat pump installers data from S3 in a usable for
 
 import pandas as pd
 import os
-
-from asf_core_data.getters.data_getters import load_s3_data
-
+import boto3
+from asf_core_data.getters.data_getters import load_s3_data, get_most_recent_batch_name
 from asf_core_data.config import base_config
 
 
-def get_raw_historical_mcs_installers(
+def get_most_recent_raw_historical_installers_data() -> pd.DataFrame:
+    """
+    Get the most recent version of the raw historical heat pump MCS certified installer data from S3.
+
+    Returns:
+        The most recent version of the raw historical installers data from MCS.
+    """
+
+    bucket = base_config.BUCKET_NAME
+    path = base_config.MCS_HISTORICAL_DATA_INPUTS_PATH
+    most_recent_file_name = get_most_recent_batch_name(
+        bucket=bucket, s3_folder_path=path, filter_keep_keywords=["installer"]
+    )
+
+    return load_s3_data(
+        bucket_name=base_config.BUCKET_NAME,
+        file_name=most_recent_file_name,
+        dtypes=base_config.raw_historical_installers_dtypes,
+    )
+
+
+def get_raw_historical_installers_data(
     raw_historical_installers_file_name: str,
 ) -> pd.DataFrame:
     """
-    Get raw historical heat pump MCS certified installer data from S3.
+    Get a specified version of the raw historical heat pump MCS certified installer data from S3.
 
     Args:
         raw_historical_mcs_installers_file_name: name of file in S3 bucket, `raw_historical_installers_YYYYMMDD.xlsx`
@@ -33,20 +53,39 @@ def get_raw_historical_mcs_installers(
     )
 
 
-def get_processed_historical_installers_data(date: str) -> pd.DataFrame:
+def get_most_recent_processed_historical_installers_data() -> pd.DataFrame:
     """
-    Get raw historical heat pump MCS certified installer data from S3.
+    Get the most recent version of the processed historical heat pump MCS certified installer data from S3.
+     Returns:
+        The most recent version of the processed historical installers data from MCS.
+    """
+    bucket = base_config.BUCKET_NAME
+    path = base_config.MCS_HISTORICAL_DATA_OUTPUTS_PATH
+    most_recent_file_name = get_most_recent_batch_name(
+        bucket=bucket, s3_folder_path=path
+    )
+
+    return load_s3_data(
+        bucket_name=bucket,
+        file_name=most_recent_file_name,
+        dtypes=base_config.preprocessed_historical_installers_dtypes,
+        columns_to_parse_as_dates=base_config.preprocessed_historical_installers_date_cols,
+    )
+
+
+def get_processed_historical_installers_data(path_to_file: str) -> pd.DataFrame:
+    """
+    Get a specified version of the processed historical heat pump MCS certified installer data from S3.
 
     Args:
-        date: YYYYMMDD, wwhere YYYY/MM/DD is the date MCS shared the file in the Data Dumps Google Drive folder.
+        path_to_file: string of format 'outputs/MCS/installers/mcs_historical_installers_YYYYMMDD.csv',
+        where YYYY/MM/DD is the date MCS shared the file in the Data Dumps Google Drive folder.
     Returns:
-        Raw historical installers heat pump data from MCS.
+        Raw historical installers data from MCS.
     """
     return load_s3_data(
         bucket_name=base_config.BUCKET_NAME,
-        file_name=base_config.PREPROCESSED_MCS_HISTORICAL_INSTALLERS_FILE_PATH.format(
-            date
-        )[1:],
+        file_name=path_to_file,
         dtypes=base_config.preprocessed_historical_installers_dtypes,
         columns_to_parse_as_dates=base_config.preprocessed_historical_installers_date_cols,
     )

--- a/asf_core_data/getters/mcs_getters/get_mcs_installers.py
+++ b/asf_core_data/getters/mcs_getters/get_mcs_installers.py
@@ -70,6 +70,7 @@ def get_most_recent_processed_historical_installers_data() -> pd.DataFrame:
         file_name=most_recent_file_name,
         dtypes=base_config.preprocessed_historical_installers_dtypes,
         columns_to_parse_as_dates=base_config.preprocessed_historical_installers_date_cols,
+        encoding="utf-8",
     )
 
 
@@ -88,4 +89,5 @@ def get_processed_historical_installers_data(path_to_file: str) -> pd.DataFrame:
         file_name=path_to_file,
         dtypes=base_config.preprocessed_historical_installers_dtypes,
         columns_to_parse_as_dates=base_config.preprocessed_historical_installers_date_cols,
+        encoding="utf-8",
     )

--- a/asf_core_data/getters/mcs_getters/get_mcs_installers.py
+++ b/asf_core_data/getters/mcs_getters/get_mcs_installers.py
@@ -1,0 +1,52 @@
+"""
+Functions to get MCS certified heat pump installers data from S3 in a usable format with correct dtypes.
+
+"""
+
+import pandas as pd
+import os
+
+from asf_core_data.getters.data_getters import load_s3_data
+
+from asf_core_data.config import base_config
+
+
+def get_raw_historical_mcs_installers(
+    raw_historical_installers_file_name: str,
+) -> pd.DataFrame:
+    """
+    Get raw historical heat pump MCS certified installer data from S3.
+
+    Args:
+        raw_historical_mcs_installers_file_name: name of file in S3 bucket, `raw_historical_installers_YYYYMMDD.xlsx`
+        where YYYY/MM/DD is the date MCS shared the file in the Data Dumps Google Drive folder.
+    Returns:
+        Raw historical installers heat pump data from MCS.
+    """
+    return load_s3_data(
+        bucket_name=base_config.BUCKET_NAME,
+        file_name=os.path.join(
+            base_config.MCS_HISTORICAL_DATA_INPUTS_PATH,
+            raw_historical_installers_file_name,
+        ),
+        dtypes=base_config.raw_historical_installers_dtypes,
+    )
+
+
+def get_processed_historical_installers_data(date: str) -> pd.DataFrame:
+    """
+    Get raw historical heat pump MCS certified installer data from S3.
+
+    Args:
+        date: YYYYMMDD, wwhere YYYY/MM/DD is the date MCS shared the file in the Data Dumps Google Drive folder.
+    Returns:
+        Raw historical installers heat pump data from MCS.
+    """
+    return load_s3_data(
+        bucket_name=base_config.BUCKET_NAME,
+        file_name=base_config.PREPROCESSED_MCS_HISTORICAL_INSTALLERS_FILE_PATH.format(
+            date
+        )[1:],
+        dtypes=base_config.preprocessed_historical_installers_dtypes,
+        columns_to_parse_as_dates=base_config.preprocessed_historical_installers_date_cols,
+    )

--- a/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
+++ b/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
@@ -1,5 +1,5 @@
 """
-Script for pre-processing historical MCS heat pump installer company data:
+Script for pre-processing historical MCS heat pump installer company data.
 - Dropping duplicate instances (if they exist);
 - Renaming columns;
 - Joining installation and design variables;
@@ -29,11 +29,6 @@ OR
 `python3 process_historical_mcs_installers.py -raw_historical_installers_filename "raw_historical_mcs_installers_YYYYMMDD.xlsx" -raw_historical_installations_filename "raw_historical_mcs_installations_YYYYMMDD.xlsx"`
 OR
 `python3 process_historical_mcs_installers.py -api_key "YOUR_API_KEY" -raw_historical_installers_filename "raw_historical_mcs_installers_YYYYMMDD.xlsx" -raw_historical_installations_filename "raw_historical_mcs_installations_YYYYMMDD.xlsx"`
-
-Companies House API additional info:
-- https://developer-specs.company-information.service.gov.uk/companies-house-public-data-api/reference/search/search-companies
-- https://developer-specs.company-information.service.gov.uk/companies-house-public-data-api/resources/companysearch?v=latest
-
 """
 
 import pandas as pd
@@ -44,7 +39,7 @@ from argparse import ArgumentParser
 from asf_core_data.config import base_config
 from asf_core_data.getters.data_getters import s3, load_s3_data, save_to_s3
 from asf_core_data.getters.mcs_getters.get_mcs_installers import (
-    get_raw_historical_mcs_installers,
+    get_raw_historical_installers_data,
 )
 from asf_core_data.getters.mcs_getters.get_mcs_installations import (
     get_raw_historical_installations_data,
@@ -674,15 +669,11 @@ if __name__ == "__main__":
     uk_geo_data = load_s3_data(s3_bucket_name, uk_geo_path)
 
     # Getting raw installations and installers data from S3
-    mcs_raw_data_path = base_config.MCS_HISTORICAL_DATA_INPUTS_PATH
-    raw_historical_installers_filename = args.raw_historical_installers_filename
-    raw_historical_installations_filename = args.raw_historical_installations_filename
-
-    raw_historical_installers = get_raw_historical_mcs_installers(
-        raw_historical_installers_filename
+    raw_historical_installers = get_raw_historical_installers_data(
+        args.raw_historical_installers_filename
     )
     raw_historical_installations = get_raw_historical_installations_data(
-        raw_historical_installations_filename
+        args.raw_historical_installations_filename
     )
 
     # Process raw historical installers data
@@ -695,12 +686,10 @@ if __name__ == "__main__":
 
     # Saving processed data to S3
     processed_data_path = base_config.PREPROCESSED_MCS_HISTORICAL_INSTALLERS_FILE_PATH
-
+    # date when data was shared by MCS in MCS data dumps
     date = args.raw_historical_installers_filename.split("installers_")[1].split(
         ".xlsx"
-    )[
-        0
-    ]  # date when data was shared by MCS in MCS data dumps
+    )[0]
 
     save_to_s3(
         s3=s3,

--- a/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
+++ b/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
@@ -190,32 +190,12 @@ def match_companies_house(company_name: str, api_key: str) -> pd.Series:
             and ("items" in company_data.keys())
             and len(company_data["items"]) > 0
         ):
-            # return data for the closest match, the one found in index 0
-            if ("address_snippet" in company_data["items"][0].keys()) and (
-                "date_of_creation" in company_data["items"][0].keys()
-            ):
-                return pd.Series(
-                    [
-                        company_data["items"][0]["address_snippet"],
-                        company_data["items"][0]["date_of_creation"],
-                    ]
-                )
-            elif "address_snippet" in company_data["items"][0].keys():
-                return pd.Series(
-                    [
-                        company_data["items"][0]["address_snippet"],
-                        None,
-                    ]
-                )
-            elif "date_of_creation" in company_data["items"][0].keys():
-                return pd.Series(
-                    [
-                        None,
-                        company_data["items"][0]["date_of_creation"],
-                    ]
-                )
-            else:
-                return pd.Series([None, None])
+           address_snippet = company_data["items"][0]["address_snippet"] if ("address_snippet" in company_data["items"][0].keys()) else None
+           date_of_creation = company_data["items"][0]["date_of_creation"] if  "date_of_creation" in company_data["items"][0].keys() else None
+           
+           return  pd.Series(
+                    [address_snippet, date_of_creation])
+        
         else:
             return pd.Series([None, None])
     else:

--- a/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
+++ b/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
@@ -411,7 +411,7 @@ def create_certified_flags(data: pd.DataFrame):
     Updates historical installers data by creating flags representing whether
     installer is certified or not for a certain technology.
 
-    If a start date exists, then if means installer is certified.
+    If a start date exists, then it means installer is certified.
 
     Args:
         data: historical installers data

--- a/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
+++ b/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
@@ -395,16 +395,13 @@ def update_full_address(
         full adress
     """
     if original_record:
-        temp = address_1
-        if not pd.isnull(address_2):
-            temp = temp + address_2 + ", "
-        if not pd.isnull(town):
-            temp = temp + town + ", "
-        if not pd.isnull(county):
-            temp = temp + county + ", "
-        if not pd.isnull(postcode):
-            temp = temp + postcode + ", "
-        return temp[:-2]
+        temp = []
+        for address_part in [address_1, address_2, town, county, postcode]:
+              if not pd.isnull(address_part):
+                    temp.append(address_part)
+        full_address = ", ".join(temp)
+        return full_address
+ 
     # if not original record, we have the full address from Companies House
     return full_address
 

--- a/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
+++ b/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
@@ -29,6 +29,9 @@ OR
 `python3 process_historical_mcs_installers.py -raw_historical_installers_filename "raw_historical_mcs_installers_YYYYMMDD.xlsx" -raw_historical_installations_filename "raw_historical_mcs_installations_YYYYMMDD.xlsx"`
 OR
 `python3 process_historical_mcs_installers.py -api_key "YOUR_API_KEY" -raw_historical_installers_filename "raw_historical_mcs_installers_YYYYMMDD.xlsx" -raw_historical_installations_filename "raw_historical_mcs_installations_YYYYMMDD.xlsx"`
+
+Note that the processing of historical installers is included the script that processes MCS data:
+python3 asf_core_daa/pipeline/mcs/generate_mcs_data.py
 """
 
 import pandas as pd

--- a/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
+++ b/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
@@ -219,7 +219,9 @@ def match_companies_house(company_name: str, api_key: str) -> pd.Series:
         return match_companies_house(company_name, api_key)
 
 
-def recompute_full_adress(date_creation, first_commisioning_date, full_address):
+def recompute_full_adress(
+    date_creation: datetime, first_commisioning_date: datetime, full_address: str
+) -> str:
     """
     If company date of creation happens before the first HP comissioning date
     then we keep the full address (good match), otherwise address to None (meaning a bad
@@ -450,7 +452,7 @@ def clean_company_name(company_name: str) -> str:
     return " ".join(company_name)
 
 
-def from_list_to_dictionary(list_values):
+def from_list_to_dictionary(list_values: list) -> dict:
     """
     Transforms a list into a dictionary where each key is matched to the first
     value in the list. Creates a mapping between each item in the list and the first one.
@@ -547,7 +549,9 @@ def position_to_value(list_of_strings: list, indices_dict: dict) -> dict:
     }
 
 
-def map_installers_same_location_different_id(postcodes, installer_data):
+def map_installers_same_location_different_id(
+    postcodes: list, installer_data: pd.DataFrame
+) -> dict:
     """
     Returns a dictionary with a mapping between company unique IDs for companies that have the same
     address but are not originally identified as the same company.
@@ -833,7 +837,13 @@ def preprocess_historical_installers(
     ]
 
 
-def create_argparser():
+def create_argparser() -> ArgumentParser:
+    """
+    Creates an argument parser that can receive the following arguments:
+    - raw historical installers file name, as `raw_historical_installers_filename`
+    - raw historical installations file name, as `raw_historical_installations_filename`
+    - companies house api key, as `api_key`
+    """
     parser = ArgumentParser()
 
     parser.add_argument(

--- a/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
+++ b/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
@@ -190,12 +190,19 @@ def match_companies_house(company_name: str, api_key: str) -> pd.Series:
             and ("items" in company_data.keys())
             and len(company_data["items"]) > 0
         ):
-           address_snippet = company_data["items"][0]["address_snippet"] if ("address_snippet" in company_data["items"][0].keys()) else None
-           date_of_creation = company_data["items"][0]["date_of_creation"] if  "date_of_creation" in company_data["items"][0].keys() else None
-           
-           return  pd.Series(
-                    [address_snippet, date_of_creation])
-        
+            address_snippet = (
+                company_data["items"][0]["address_snippet"]
+                if ("address_snippet" in company_data["items"][0].keys())
+                else None
+            )
+            date_of_creation = (
+                company_data["items"][0]["date_of_creation"]
+                if "date_of_creation" in company_data["items"][0].keys()
+                else None
+            )
+
+            return pd.Series([address_snippet, date_of_creation])
+
         else:
             return pd.Series([None, None])
     else:
@@ -352,17 +359,17 @@ def get_missing_installers_info(
     )
 
     # rename columns to match installers table
-    missing_installers.rename(columns=
-        {
+    missing_installers.rename(
+        columns={
             "installation_company_name": "company_name",
             "installation_company_mcs_number": "mcs_certificate_number",
-        }
+        },
         inplace=True,
     )
 
     # dropping unecessary variables
-    missing_installers.drop(columns=
-        ["date_of_creation"],
+    missing_installers.drop(
+        columns=["date_of_creation"],
         inplace=True,
     )
 
@@ -395,11 +402,11 @@ def update_full_address(
     if original_record:
         temp = []
         for address_part in [address_1, address_2, town, county, postcode]:
-              if not pd.isnull(address_part):
-                    temp.append(address_part)
+            if not pd.isnull(address_part):
+                temp.append(address_part)
         full_address = ", ".join(temp)
         return full_address
- 
+
     # if not original record, we have the full address from Companies House
     return full_address
 
@@ -457,7 +464,7 @@ def from_list_to_dictionary(list_values):
         Dictionary mapping all values to the first one
         e.g. {"Company B":"Company A", "Company A trading as Company B": "Company A"}
     """
-    return {value : list_values[0] for value in list_values[1:]}
+    return {value: list_values[0] for value in list_values[1:]}
 
 
 def dictionary_mapping_trading_as_company_names(

--- a/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
+++ b/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
@@ -352,19 +352,17 @@ def get_missing_installers_info(
     )
 
     # rename columns to match installers table
-    missing_installers.rename(
+    missing_installers.rename(columns=
         {
             "installation_company_name": "company_name",
             "installation_company_mcs_number": "mcs_certificate_number",
-        },
-        axis=1,
+        }
         inplace=True,
     )
 
     # dropping unecessary variables
-    missing_installers.drop(
+    missing_installers.drop(columns=
         ["date_of_creation"],
-        axis=1,
         inplace=True,
     )
 

--- a/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
+++ b/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
@@ -484,7 +484,7 @@ def dictionary_mapping_trading_as_company_names(
         A dictionary mapping company names.
     """
 
-    # For each instance in data, it creates a ist with all possible versions of each company names
+    # For each instance in data, it creates a list with all possible versions of each company names
     # splitting string by "trading as". E.g. "A trading as B" -> ["A", "B"]
     trading_as_companies["list"] = trading_as_companies[
         "processed_company_name"

--- a/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
+++ b/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
@@ -457,10 +457,7 @@ def from_list_to_dictionary(list_values):
         Dictionary mapping all values to the first one
         e.g. {"Company B":"Company A", "Company A trading as Company B": "Company A"}
     """
-    dictionary = dict()
-    for value in list_values[1:]:
-        dictionary[value] = list_values[0]
-    return dictionary
+    return {value : list_values[0] for value in list_values[1:]}
 
 
 def dictionary_mapping_trading_as_company_names(

--- a/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
+++ b/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
@@ -1,0 +1,837 @@
+"""Processing historical MCS installer company data.
+
+Installer name/ company name/ installation company name are used interchangebly throughout the whole script.
+
+To run script, (in activated conda environment) python process_historical_mcs_installers.py -key API KEY
+"""
+
+import pandas as pd
+import numpy as np
+import requests
+import random
+import time
+import os
+from datetime import datetime
+from argparse import ArgumentParser
+from asf_core_data.config import base_config
+from asf_core_data.getters.data_getters import s3, load_s3_data, save_to_s3
+from asf_core_data.getters.mcs_getters.get_historical_mcs_installers import (
+    get_raw_historical_mcs_installers,
+)
+from asf_core_data.getters.mcs_getters.get_mcs_installations import (
+    get_raw_historical_installations_data,
+)
+
+
+def basic_preprocessing_of_installations(raw_historical_installations: pd.DataFrame):
+    """
+    Applies basic preprocessing to raw installations to make it easier to work with:
+    - Renaming columns (lower case, spaces to underscore, etc.);
+    - Extracting certification body and certification number info from original var
+    Args:
+        raw_historical_installations: raw historical installations table
+    """
+
+    raw_historical_installations.columns = rename_columns(
+        raw_historical_installations.columns
+    )
+
+    raw_historical_installations["certification_body"] = (
+        raw_historical_installations["installation_company_mcs_number"]
+        .str.split(" ")
+        .str[0]
+    )
+
+    raw_historical_installations["installation_company_mcs_number"] = (
+        raw_historical_installations["installation_company_mcs_number"]
+        .str.split(" ")
+        .str[1]
+        .astype(int)
+    )
+
+
+def rename_columns(cols: list) -> list:
+    """
+    Renames a list of strings, e.g. a list of column names, by:
+    - applying lower case
+    - replacing "heat pump" by "hp"
+    - replacing " " and "/" by "_"
+    - correcting the word address.
+
+    Args:
+        cols: original column names
+    Returns:
+        Renamed column names
+    """
+    cols = [c.lower() for c in cols]
+    changes_dict = {"heat pump": "hp", " ": "_", "/": "_", "adddress": "address"}
+    for item in changes_dict.keys():
+        cols = [c.replace(item, changes_dict[item]) for c in cols]
+
+    return cols
+
+
+def joining_installation_and_design_vars(data: pd.DataFrame):
+    """
+    Joins together installation and design date variables and drops original variables.
+
+    If installation date exist, we keep installation date. Otherwise, we keep design date.
+
+    Args:
+        data: historical installer data
+    """
+
+    installation_cols = [col for col in data.columns if "installation" in col]
+    for col in installation_cols:
+        date_var = col.replace("installation_", "")
+        correspondent_design_var_name = col.replace("installation", "design")
+        data[date_var] = data.apply(
+            lambda x: x[col]
+            if not pd.isnull(x[col])
+            else x[correspondent_design_var_name],
+            axis=1,
+        )
+
+        data.drop([col, correspondent_design_var_name], axis=1, inplace=True)
+
+
+def deal_with_versions_of_trading_as(installer_name: str) -> str:
+    """
+    Replaces several expressions representing "trading as" by the expression
+    "trading as" in the installer name.
+
+    Args:
+        installer_name: installer name
+
+    Returns:
+        updated installer name
+    """
+    versions = {
+        "t/a": "trading as",
+        " ta ": " trading as ",
+        "a trading name of": "trading as",
+        "the trading name of": "trading as",
+    }
+    for item in versions:
+        installer_name = installer_name.replace(item, versions[item])
+
+    return installer_name
+
+
+# copied from process_mcs_utils.py and changed slightly
+def match_companies_house(company_name: str, api_key: str) -> pd.Series:
+    """
+    Fuzzy matches company name with company house API and
+    returns Companies House information: company full address and date of creation.
+
+    Args:
+        company_name: Company name to query company house API with.
+        api_key: API key to call live company house API endpoint.
+    Returns:
+        company_info: pandas Series with 2 values, full address and creation date
+    """
+
+    # E.g. "Flo Group LTD T/A Flo Renewables" -> "flo renewables"
+    company_name = company_name.lower()
+    if "trading as" in company_name:
+        company_name = deal_with_versions_of_trading_as(company_name).split(
+            " trading as "
+        )[1]
+
+    base_url = f"https://api.company-information.service.gov.uk/search/companies?q={company_name}"
+
+    response = requests.get(base_url, auth=(api_key, ""))
+
+    # developer guidelines state you can make 600 requests per 5 mins
+    # this translates into 1 request every 0.5 seconds
+    time.sleep(0.5)
+
+    response_status_code = response.status_code
+
+    if response_status_code == 200:
+        company_data = response.json()
+        if (
+            (company_data is not None)
+            and ("items" in company_data.keys())
+            and len(company_data["items"]) > 0
+        ):
+            # return that for the closest match, the one found in index 0
+            if ("address_snippet" in company_data["items"][0].keys()) and (
+                "date_of_creation" in company_data["items"][0].keys()
+            ):
+                return pd.Series(
+                    [
+                        company_data["items"][0]["address_snippet"],
+                        company_data["items"][0]["date_of_creation"],
+                    ]
+                )
+            elif "address_snippet" in company_data["items"][0].keys():
+                return pd.Series(
+                    [
+                        company_data["items"][0]["address_snippet"],
+                        None,
+                    ]
+                )
+            elif "date_of_creation" in company_data["items"][0].keys():
+                return pd.Series(
+                    [
+                        None,
+                        company_data["items"][0]["date_of_creation"],
+                    ]
+                )
+            else:
+                return pd.Series([None, None])
+        else:
+            return pd.Series([None, None])
+    else:
+        if response_status_code >= 400 and response_status_code < 500:
+            raise Exception(
+                "Cannot get data, the program will stop!\nHTTP {}: {}".format(
+                    response_status_code, response.text
+                )
+            )
+        sleep_seconds = random.randint(5, 60)
+        print(
+            "Cannot get data, your program will sleep for {} seconds...\nHTTP {}: {}".format(
+                sleep_seconds, response_status_code, response.text
+            )
+        )
+        time.sleep(sleep_seconds)
+        return match_companies_house(company_name, api_key)
+
+
+def recompute_full_adress(date_creation, first_commisioning_date, full_address):
+    """
+    If company date of creation happens before the first HP comissioning date
+    then we keep the full address (good match), otherwise address to None (bad batch).
+    Args:
+        date_creation: date company was created, according to match from Companies House
+        first_comissioning_date: first HP comissioning date according to HP installations data
+        full_address: full address retrieved from Companies House match
+    Returns:
+        recomputed full address.
+    """
+    if pd.isnull(date_creation) or pd.isnull(first_commisioning_date):
+        return full_address
+    else:
+        return full_address if date_creation <= first_commisioning_date else None
+
+
+def get_missing_installers_info(
+    installations: pd.DataFrame, installers: pd.DataFrame, companies_house_api_key: str
+) -> pd.DataFrame:
+    """
+    Gets information about installers missing from historical installers table, i.e.
+    installers with installations but with no info in installers table.
+    Information comes from two sources: 1) historicak installations table and from 2) Companies House API.
+
+    1)  historical installations:
+    - Start by merging installations and installers to identify missing installers info;
+    - Get company name, certification number, certification body, technology type and min
+    and max comission dates (to then infer certification start and end dates)
+
+    2) Companies House API:
+    - Full address;
+    - Company date of creation (comparing this to min HP commission date serves as a check for a good match)
+
+    Args:
+        installations: historical installations table
+        installers: historical installations table
+        companies_house_api_key: Companies house personal API key
+
+    Returns:
+        missing installers information dataframe.
+    """
+
+    # Merge the two datasets on pair (company_name, certificate_number)
+    merged_data = installations.merge(
+        right=installers[["company_name", "mcs_certificate_number"]],
+        how="left",
+        left_on=["installation_company_name", "installation_company_mcs_number"],
+        right_on=["company_name", "mcs_certificate_number"],
+    )
+
+    # Missing installers are those for which there is no match i.e. company_name/mcs_certificate_number missing
+    missing_installers = merged_data[
+        pd.isnull(merged_data["company_name"])
+        | pd.isnull(merged_data["mcs_certificate_number"])
+    ]
+
+    # Info we know about missing installers from the installations table
+    missing_installers = missing_installers[
+        [
+            "installation_company_name",
+            "installation_company_mcs_number",
+            "certification_body",
+            "technology_type",
+            "commissioning_date",
+        ]
+    ]
+
+    # We infer the certification start and end dates from the min and max commisioning dates for each technology
+    missing_installers = (
+        missing_installers.groupby(
+            [
+                "installation_company_name",
+                "installation_company_mcs_number",
+                "certification_body",
+                "technology_type",
+            ]
+        )
+        .agg(
+            start_date=("commissioning_date", np.min),
+            end_date=("commissioning_date", np.max),
+        )
+        .unstack()
+    )
+
+    # Renaming columns to match those in the historical installers table e.g. air_source_hp_start_date
+    new_column_names = [
+        rename_columns(missing_installers.columns.get_level_values(1))[i]
+        + "_"
+        + missing_installers.columns.get_level_values(0)[i]
+        for i in range(len(missing_installers.columns))
+    ]
+    missing_installers.columns = new_column_names
+    missing_installers.reset_index(inplace=True)
+
+    # original_record is set to False as these are not originally in the installers table
+    missing_installers["original_record"] = [
+        False for i in range(len(missing_installers))
+    ]
+
+    # fuzzy match installer companies NOT in installer company data using companies house API to get address info
+    missing_installers[["full_address", "date_of_creation"]] = missing_installers.apply(
+        lambda x: match_companies_house(
+            x["installation_company_name"], companies_house_api_key
+        ),
+        axis=1,
+    )
+    missing_installers["date_of_creation"] = missing_installers[
+        "date_of_creation"
+    ].apply(lambda x: datetime.strptime(x, "%Y-%m-%d") if not pd.isnull(x) else x)
+
+    # We only keep address info if the company creation date is before the first comissioning date (serves as a check)
+    start_date_cols = [col for col in missing_installers if "start_date" in col]
+    missing_installers["first_commissioning_date"] = missing_installers[
+        start_date_cols
+    ].min(axis=1)
+
+    missing_installers["full_address"] = missing_installers.apply(
+        lambda x: recompute_full_adress(
+            x["date_of_creation"], x["first_commissioning_date"], x["full_address"]
+        ),
+        axis=1,
+    )
+
+    # extract address_1 and postcode from full_address variable
+    missing_installers["address_1"] = missing_installers["full_address"].apply(
+        lambda x: x.split(",")[0] if x is not None else None
+    )
+    missing_installers["postcode"] = missing_installers["full_address"].apply(
+        lambda x: x.split(",")[-1].strip() if x is not None else None
+    )
+
+    # rename columns to match installers table
+    missing_installers.rename(
+        {
+            "installation_company_name": "company_name",
+            "installation_company_mcs_number": "mcs_certificate_number",
+        },
+        axis=1,
+        inplace=True,
+    )
+
+    # dropping unecessary variables
+    missing_installers.drop(
+        ["date_of_creation"],
+        axis=1,
+        inplace=True,
+    )
+
+    return missing_installers
+
+
+def update_full_address(
+    address_1: str,
+    address_2: str,
+    town: str,
+    county: str,
+    postcode: str,
+    original_record: str,
+    full_address: str,
+) -> str:
+    """
+    Updates full_address variable with full address for original records (when original_records is True).
+
+    Args:
+        address_1: first line of address
+        address_2: second line of address
+        town: town
+        county: county
+        postcode: postcode
+        original_record: True if record originally in
+    Returns:
+        full adress
+    """
+    if original_record:
+        temp = address_1
+        if not pd.isnull(address_2):
+            temp = temp + address_2 + ", "
+        if not pd.isnull(town):
+            temp = temp + town + ", "
+        if not pd.isnull(county):
+            temp = temp + county + ", "
+        if not pd.isnull(postcode):
+            temp = temp + postcode + ", "
+        return temp[:-2]
+    else:  # if not original record, we have the full address from Companies House
+        return full_address
+
+
+def create_certified_flags(data: pd.DataFrame):
+    """
+    Updates historical installers data by creates flags representing whether
+    installer is certified or not for a certain technology.
+
+    If a start date exists, then if means installer is certified.
+
+    Args:
+        data: historical installers data
+    """
+
+    # start date variables for all tech types e.g. air_source_hp_start_date
+    start_date_cols = [col for col in data.columns if "start_date" in col]
+
+    for col in start_date_cols:
+        # example of flag_var: air_source_hp_certified
+        flag_var = col.split("start_date")[0] + "certified"
+        data[flag_var] = ~pd.isnull(data[col])
+
+
+# copied from process_mcs_utils.py and changed slightly
+def clean_company_name(company_name: str) -> str:
+    """
+    Cleans installation company name by:
+        - company name to lower case;
+        - removes punctuation;
+        - removing "company" stopwords like ltd, limited;
+
+    Args:
+        company_name: Name of company to clean.
+    Returns:
+        company_name: Cleaned company name.
+    """
+    company_stopwords = ["ltd", "ltd.", "limited", "limited.", "old", "account"]
+
+    company_name = company_name.lower().translate(str.maketrans("", "", "()-,/.&"))
+    company_name = [
+        comp for comp in company_name.split() if comp not in company_stopwords
+    ]
+
+    return " ".join(company_name)
+
+
+def from_list_to_dictionary(list_values):
+    """
+    Transforms a list into a dictionary where each key is matched to the first
+    value in the list.
+    Arg:
+        list_values: a list of values e.g. ["Company A", "Company B", "Company A trading as Company B"]
+    Returns:
+        Dictionary mapping all values to the first one
+        e.g. {"Company B":"Company A", "Company A trading as Company B": "Company A"}
+    """
+    dictionary = dict()
+    for value in list_values:
+        dictionary[value] = list_values[0]
+    return dictionary
+
+
+def dictionary_mapping_trading_as_company_names(
+    trading_as_companies: pd.DataFrame,
+) -> dict:
+    """
+    Creates a dictionary mapping company names containing the "trading as" in the name.
+
+    As an example, if we have 3 original installer names:
+    - "Company A"
+    - "Company B"
+    - "Company A trading as Company B"
+    They should all be mapped identified the same company, e.g. identified as "Company A".
+
+    Args:
+        trading_as_companies: dataframe containing a processed_company_name variable where
+        company names contain the "trading as" expression.
+    Returns:
+        A dictionary mapping company names.
+    """
+
+    # List with all possible company names: "A trading as B" -> ["A", "B"]
+    trading_as_companies["list"] = trading_as_companies[
+        "processed_company_name"
+    ].str.split(" trading as ")
+    # Adding full name as well : ["A", "B", "A trading as B"]
+    trading_as_companies["list"] = trading_as_companies.apply(
+        lambda x: x["list"] + [x["processed_company_name"]], axis=1
+    )
+
+    # Transforms the list into a dictionary where each key is matched to the first value in the list:
+    # ["A", "B", "A trading as B"] -> {"B":"A", "A trading as B":"A"}
+    trading_as_companies["dictionary"] = trading_as_companies["list"].apply(
+        from_list_to_dictionary
+    )
+
+    # Transforms the pd.Series trading_as_companies["dictionary"] into one dictionary
+    trading_as_dictionary = {
+        k: v for d in trading_as_companies["dictionary"] for k, v in d.items()
+    }
+
+    return trading_as_dictionary
+
+
+def matching_position_of_subset_items(list_of_strings: list) -> dict:
+    """
+    Returns a dictionary matching the position of strings in a list which are a subset of each other.
+    Example
+    set_of_strings = {"company a ltd", "a ltd", "a"}
+    Output: {0: 2, 1: 2} (note that initially, 0 is mapped to 1 but then that's overwritten by 0 being mapped to 2)
+
+    Args:
+        list_of_strings: a list of strings
+    Returns:
+        A dictionary matching the position of strings that are subset of another.
+    """
+    return {
+        i: j
+        for i in range(len(list_of_strings) - 1)
+        for j in range(i + 1, len(list_of_strings), 1)
+        if (list_of_strings[i] in list_of_strings[j])
+        or (list_of_strings[j] in list_of_strings[i])
+    }
+
+
+def position_to_value(list_of_strings: list, indices_dict: dict) -> dict:
+    """
+    Returns dictionary resulting from mapping a dictionary with indices as key-value pairs to a list of strings.
+    Args:
+        list_of_strings: list of strings, e.g. ["a", "b", "c]
+        indices_dict: dictionary of indices, e.g. {0:2, 1:2}
+    Returns:
+        The mapped dictionary e.g. {"a":"c", "b":"c"}
+
+    """
+    return {
+        list_of_strings[key]: list_of_strings[indices_dict[key]]
+        for key in indices_dict.keys()
+    }
+
+
+def match_places_same_location_different_id(postcodes, installer_data):
+    """
+    Returns a dictionary with a mapping between company unique IDs.
+
+    Given companies that have the same company postcode and address_1, but different company unique IDs,
+    we create a map between the IDs.
+
+    Args:
+        postcodes: list of postcodes corresponding to multiple company unique IDs
+        installer_data: installer data
+    Returns:
+        A dictionary with a mapping between company unique IDs that represent the same company.
+    """
+
+    # Installer data with potential for mapping
+    installers_not_matched = installer_data[installer_data["postcode"].isin(postcodes)]
+
+    # removing any punctuation and spaces: e.g. both "Unit 1, ABC Road" and "Unit1 ABC Road" will translate to "unit1abcroad"
+    installers_not_matched["comparable_address_1"] = (
+        installers_not_matched["address_1"]
+        .str.lower()
+        .str.translate(str.maketrans("", "", "()-,/."))
+        .str.replace(" ", "")
+    )
+
+    installers_not_matched = installers_not_matched.groupby("postcode").agg(
+        comparable_address_1=("comparable_address_1", list),
+        company_unique_id=("company_unique_id", list),
+    )
+
+    possible_adresses_and_names = installers_not_matched[
+        installers_not_matched["comparable_address_1"].apply(len) > 1
+    ]
+    possible_adresses_and_names["indices_mapping"] = possible_adresses_and_names[
+        "comparable_address_1"
+    ].apply(matching_position_of_subset_items)
+    possible_adresses_and_names["matches"] = possible_adresses_and_names.apply(
+        lambda x: position_to_value(x["company_unique_id"], x["indices_mapping"]),
+        axis=1,
+    )
+
+    # Transforms the pd.Series trading_as_companies["dictionary"] into one dictionary
+    new_matches = {
+        k: v for d in possible_adresses_and_names["matches"] for k, v in d.items()
+    }
+
+    return new_matches
+
+
+def create_installer_unique_id(installer_data: pd.DataFrame):
+    """
+    Creates a string unique identifier for each installer company, since multiple company names might
+    refer to the same installer.
+    E.g. "Company A Ltd", "Company A Limited", "Company A (old account), "Company A t/a Company B"
+    all refer to the same company which will be identified by the unique ID "company a".
+
+    Identifiers are created from the original company names by:
+    - cleaning the company name (lowe case, removing stopwords and punctuation);
+    - Merge all different "trading as" expressions into one;
+    - Creating a dictionary to map companies trading as other companies to be identified as the same;
+    - Creating a dictionary to map companies with slightly different names with address in the same location;
+
+    Args:
+        installer_data: historical installers data
+    """
+    # Cleaning company name
+    installer_data["processed_company_name"] = installer_data["company_name"].apply(
+        clean_company_name
+    )
+
+    # Dealing with different versions of "trading as"
+    installer_data["processed_company_name"] = installer_data[
+        "processed_company_name"
+    ].apply(deal_with_versions_of_trading_as)
+
+    # Unique companies containing "trading as" in the name
+    trading_as_companies = installer_data[
+        installer_data["processed_company_name"].str.contains("trading as")
+    ][["processed_company_name"]]
+    trading_as_companies.drop_duplicates("processed_company_name", inplace=True)
+
+    # Creating dicitionary to map "trading as" companies to the same company name
+    trading_as_dictionary = dictionary_mapping_trading_as_company_names(
+        trading_as_companies
+    )
+
+    # Applying the mapping created above to create the company unique ID
+    installer_data["company_unique_id"] = installer_data[
+        "processed_company_name"
+    ].apply(
+        lambda x: trading_as_dictionary[x] if x in trading_as_dictionary.keys() else x
+    )
+
+    # Droping processed_company_name as no longer needed
+    installer_data.drop("processed_company_name", axis=1, inplace=True)
+
+    # Check for those that have the same location but not identified as being the same
+    same_postcode_no_match = installer_data.groupby("postcode", as_index=False)[
+        ["company_unique_id"]
+    ].nunique()
+    same_postcode_no_match = same_postcode_no_match[
+        same_postcode_no_match["company_unique_id"] > 1
+    ]["postcode"].unique()
+    new_matches = match_places_same_location_different_id(
+        same_postcode_no_match, installer_data
+    )
+    installer_data["company_unique_id"] = installer_data["company_unique_id"].apply(
+        lambda x: new_matches[x] if x in new_matches.keys() else x
+    )
+
+
+def geocode_postcode(data: pd.DataFrame, geodata: pd.DataFrame) -> pd.DataFrame:
+    """
+    Updates data with latitude and longitude columns, by merging with geodata
+    on postode column. Also transforms postcode column by removing the space.
+
+    Args:
+        data: DataFrame with postcode column.
+        geodata: DataFrame with postcode, latitude and longitude columns.
+    """
+
+    geodata["postcode"] = geodata["postcode"].str.replace(" ", "")
+
+    data["postcode"] = data["postcode"].str.upper().str.replace(" ", "")
+    data = data.merge(
+        geodata[["postcode", "latitude", "longitude"]], how="left", on="postcode"
+    )
+
+    return data
+
+
+def add_certification_body_info(installer_data, installations_data):
+    """
+    Adds certification body information to each instance of the historical installers table.
+
+    Historical installers data does not come with certification body information, only with certification number.
+    Hence, we can use the company name and the certification number to match to the installations table and get the
+    certification body from there.
+
+
+    """
+    installations_match_vars = [
+        "installation_company_name",
+        "installation_company_mcs_number",
+    ]
+    installers_match_vars = ["company_name", "mcs_certificate_number"]
+
+    # Unique pairs (installation_company_name, installation_company_mcs_number)
+    unique_pairs_in_installations = installations_data.drop_duplicates(
+        installations_match_vars
+    )[installations_match_vars]
+
+    # Certification number as float in both tables in order to be able to compare
+    # installer_data["mcs_certificate_number"] = installer_data["mcs_certificate_number"].astype(float)
+
+    # Merge installer with installation data to add the certification_body to the installer data
+    installer_data = installer_data.merge(
+        unique_pairs_in_installations,
+        how="left",
+        right_on=installations_match_vars,
+        left_on=installers_match_vars,
+    )
+
+    installer_data.drop(installations_match_vars, axis=1, inplace=True)
+
+
+def preprocess_historical_installers(
+    raw_historical_installers,
+    raw_historical_installations,
+    geographical_data,
+    companies_house_api_key,
+):
+    """
+    Pre-processes raw historical installers data by:
+    - Droping duplicate instances;
+    - Renaming columns;
+    - Joining installation and design variables;
+    - Creating flag variables for whether an installer is certified for a certain technology;
+    - Geocoding data by adding latitude and longitude;
+    - Creating a variable that uniquely identifies installers;
+    - Adding certification body information;
+
+    Args:
+        raw_historical_installers: raw historical installers data
+        raw_historical_installations: raw historical installations data
+        geographical_data: geographical data
+        companies_house_api_key: companies house API key
+    """
+
+    # Apply basic preprocessing to table of installations
+    basic_preprocessing_of_installations(raw_historical_installations)
+
+    # Dropping duplicate lines
+    raw_historical_installers.drop_duplicates(inplace=True)
+
+    # Renaming columns
+    raw_historical_installers.columns = rename_columns(
+        raw_historical_installers.columns
+    )
+
+    # Joining installation and design variables
+    joining_installation_and_design_vars(raw_historical_installers)
+
+    # flag "original_records" (if originally in installers or inputed from installations)
+    raw_historical_installers["original_record"] = [
+        True for i in range(len(raw_historical_installers))
+    ]
+
+    # Get info installers with installations but with info missing from installers
+    missing_installers = get_missing_installers_info(
+        raw_historical_installations, raw_historical_installers, companies_house_api_key
+    )
+
+    raw_historical_installers = pd.concat(
+        [raw_historical_installers, missing_installers]
+    )
+    raw_historical_installers.reset_index(drop=True, inplace=True)
+
+    # Updating address_snippet variable
+    raw_historical_installers["full_address"] = raw_historical_installers.apply(
+        lambda x: update_full_address(
+            x["address_1"],
+            x["address_2"],
+            x["town"],
+            x["county"],
+            x["postcode"],
+            x["original_record"],
+            x["full_address"],
+        ),
+        axis=1,
+    )
+
+    # Creating flag for whether certified for a certain technology
+    create_certified_flags(raw_historical_installers)
+
+    # Geocoding data
+    raw_historical_installers = geocode_postcode(
+        raw_historical_installers, geographical_data
+    )
+
+    # Create installer unique ID
+    create_installer_unique_id(raw_historical_installers)
+
+    # Certification body information
+    add_certification_body_info(raw_historical_installers, raw_historical_installations)
+
+    return raw_historical_installers[base_config.historical_installers_columns_order]
+
+
+def create_argparser():
+    parser = ArgumentParser()
+
+    parser.add_argument(
+        "--raw_historical_installers_filename",
+        help="Raw historical installers file name",
+        default="raw_historical_mcs_installers_20230207",
+        type=str,
+    )
+    parser.add_argument(
+        "--raw_historical_installations_filename",
+        help="Raw historical installations file name",
+        default="raw_historical_mcs_installers_20230207",
+        type=str,
+    )
+    parser.add_argument(
+        "-key",
+        "--api_key",
+        help="Companies House API key",
+        default=os.environ.get("COMPANIES_HOUSE_API_KEY"),
+        type=str,
+    )
+
+    return parser
+
+
+if __name__ == "__main__":
+    bucket_name = base_config.BUCKET_NAME
+    uk_geo_path = base_config.POSTCODE_TO_COORD_PATH
+
+    uk_geo_data = load_s3_data(bucket_name, uk_geo_path)
+    mcs_raw_data_path = base_config.S3_NEW_MCS_DATA_DUMP_DIR
+
+    parser = create_argparser()
+    args = parser.parse_args()
+
+    raw_historical_installers = get_raw_historical_mcs_installers()
+
+    raw_historical_installations = get_raw_historical_installations_data()
+
+    processed_historical_installers = preprocess_historical_installers(
+        raw_historical_installers,
+        raw_historical_installations,
+        uk_geo_data,
+        args.api_key,
+    )
+
+    processed_data_path = base_config.PREPROCESSED_MCS_HISTORICAL_INSTALLERS_PATH
+
+    # date when data was shared by MCS in MCS data dumps
+    date = args.raw_historical_installations_filename.split("installers_")[1]
+
+    # saving data to S3
+    save_to_s3(
+        s3,
+        bucket_name,
+        processed_historical_installers,
+        processed_data_path.format(date),
+    )

--- a/asf_core_data/pipeline/mcs/process/process_mcs_installations.py
+++ b/asf_core_data/pipeline/mcs/process/process_mcs_installations.py
@@ -13,8 +13,9 @@ from asf_core_data.getters.mcs_getters.get_mcs_installations import (
 from asf_core_data.getters.mcs_getters.get_mcs_installers import (
     get_processed_historical_installers_data,
 )
-from asf_core_data.pipeline.mcs.process.process_mcs_utils import clean_company_name
-
+from asf_core_data.getters.mcs_getters.get_mcs_installers import (
+    get_most_recent_processed_historical_installers_data,
+)
 from asf_core_data.config import base_config
 
 # %%
@@ -143,7 +144,7 @@ def get_installer_unique_id(
 
 
 def get_processed_installations_data(refresh=True):
-    """Get processed MCS installations data.
+    """Process MCS installations data and add information about company unique ID.
 
     Args:
         refresh (bool): Whether or not to redownload the unprocessed data
@@ -155,14 +156,14 @@ def get_processed_installations_data(refresh=True):
 
     installations_data = get_raw_installations_data(refresh=refresh)
 
-    # we need to change this later to account for other versions
-    historical_installers_processed_data = get_processed_historical_installers_data(
-        "20230207"
-    )
-
     installations_data = add_hp_features(installations_data)
     installations_data = mask_outliers(installations_data)
     installations_data = identify_clusters(installations_data)
+
+    # getting latest batch of processed historical installers data
+    historical_installers_processed_data = (
+        get_most_recent_processed_historical_installers_data()
+    )
 
     # Adding variable with unique installer ID
     installations_data = get_installer_unique_id(

--- a/asf_core_data/pipeline/mcs/process/process_mcs_installations.py
+++ b/asf_core_data/pipeline/mcs/process/process_mcs_installations.py
@@ -120,7 +120,9 @@ def identify_clusters(hps, time_interval=base_config.MCS_CLUSTER_TIME_INTERVAL):
     return hps
 
 
-def get_installer_unique_id(installations, installers):
+def get_installer_unique_id(
+    installations: pd.DataFrame, installers: pd.DataFrame
+) -> pd.DataFrame:
     """
     Updates installations table by adding the unique installer ID.
     Args:
@@ -131,11 +133,13 @@ def get_installer_unique_id(installations, installers):
     installations = installations.merge(
         right=installers[["company_name", "company_unique_id"]],
         how="left",
-        left_on=["Installation Company Name"],
+        left_on=["installer_name"],
         right_on="company_name",
     )
 
-    installations.drop(["company_name"], axis=1, inplace=True)
+    installations.drop(columns=["company_name"], inplace=True)
+
+    return installations
 
 
 def get_processed_installations_data(refresh=True):
@@ -161,6 +165,8 @@ def get_processed_installations_data(refresh=True):
     installations_data = identify_clusters(installations_data)
 
     # Adding variable with unique installer ID
-    get_installer_unique_id(installations_data, historical_installers_processed_data)
+    installations_data = get_installer_unique_id(
+        installations_data, historical_installers_processed_data
+    )
 
     return installations_data

--- a/asf_core_data/pipeline/mcs/process/process_mcs_installers.py
+++ b/asf_core_data/pipeline/mcs/process/process_mcs_installers.py
@@ -1,6 +1,11 @@
 # %%
 # File: asf_core_data/pipeline/mcs/process/process_mcs_installers.py
-"""Processing MCS installer company data.
+"""
+--- Legacy script ---
+This is a legacy script that allows to process installer snapshot data, i.e. data from installers certified on
+the date the data was collected by the MCS team.
+
+This script allows for processing MCS installer company data.
 
 To run script, (in activated conda environment) python process_mcs_installers.py -key API KEY
 """

--- a/asf_core_data/pipeline/mcs/process/process_mcs_utils.py
+++ b/asf_core_data/pipeline/mcs/process/process_mcs_utils.py
@@ -1,7 +1,11 @@
 # File: asf_core_data/pipeline/mcs/process/process_mcs_utils.py
 """
-functions used to preprocess mcs data across installations and
-installer company data.
+Functions used to preprocess mcs data across installations and installer company data.
+
+Companies House API additional info:
+- https://developer-specs.company-information.service.gov.uk/companies-house-public-data-api/reference/search/search-companies
+- https://developer-specs.company-information.service.gov.uk/companies-house-public-data-api/resources/companysearch?v=latest
+
 """
 # %%
 
@@ -13,80 +17,6 @@ import numpy as np
 import random
 
 # %%
-
-colnames_dict = {
-    "Version Number": "version",
-    "Certificate Creation Date": "cert_date",
-    "Commissioning Date": "commission_date",
-    "Address Line 1": "address_1",
-    "Address Line 2": "address_2",
-    "Address Line 3": "address_3",
-    "County": "county",
-    "Postcode": "postcode",
-    "Local Authority": "local_authority",
-    "Total Installed Capacity": "capacity",
-    "Estimated Annual Generation": "estimated_annual_generation",
-    "Installation Company Name": "installer_name",
-    "Green Deal Installation?": "green_deal",
-    "Products": "products",
-    "Flow temp/SCOP ": "flow_scop",
-    "Technology Type": "tech_type",
-    "Installation Type": "installation_type",
-    " Installation Type": "installation_type",
-    "End User Installation Type": "end_user_installation_type",
-    "Installation New at Commissioning Date?": "new",
-    "Renewable System Design": "design",
-    "Annual Space Heating Demand": "heat_demand",
-    "Annual Water Heating Demand": "water_demand",
-    "Annual Space Heating Supplied": "heat_supplied",
-    "Annual Water Heating Supplied": "water_supplied",
-    "Installation Requires Metering?": "metering",
-    "RHI Metering Status": "rhi_status",
-    "RHI Metering Not Ready Reason": "rhi_not_ready",
-    "Number of MCS Certificates": "n_certificates",
-    "Heating System Type": "system_type",
-    "Alternative Heating System Type": "alt_type",
-    "Alternative Heating System Fuel Type": "alt_fuel",
-    "Overall Cost": "cost",
-    "Fuel Type": "fuel_type",
-    "Installation Company MCS Number": "installation_company_mcs_number",  # new var provided now in installations
-}
-
-mcs_companies_dict = {
-    "Company Name": "installer_name",
-    "MCS certificate number": "certificate_number",
-    "Add 1": "address_1",
-    "Add2": "address_2",
-    "Town": "town",
-    "County": "county",
-    "PCode": "postcode",
-    "Solar Thermal": "solar_thermal",
-    "Wind Turbines": "wind_turbines",
-    "Air Source Heat Pumps": "air_source_hps",
-    "Exhaust Air Heat Pumps": "exhaust_air_hps",
-    "Biomass": "biomass",
-    "Solar Photovoltaics": "solar_pv",
-    "Micro CHP": "micro_chp",
-    "Solar Assisted Heat Pump": "solar_assisted_hps",
-    "Gas Absorption Heat Pump": "gas_absorption_hps",
-    "Ground/Water Source Heat Pump": "ground_water_hps",
-    "Battery Storage": "battery_storage",
-    "Eastern Region": "eastern_region",
-    "East Midlands Region": "east_midlands_region",
-    "London Region": "london_region",
-    "North East Region": "north_east_region",
-    "North West Region": "north_west_region",
-    "South East Region": "south_east_region",
-    "South West Region": "south_west_region",
-    "West Midlands Region": "west_midlands_region",
-    "Yorkshire Humberside Region": "yorkshire_humberside_region",
-    "Northern Ireland Region": "northern_ireland_region",
-    "Scotland Region": "scotland_region",
-    "Wales Region": "wales_region",
-    "Effective From": "effective_from",
-    "Consumer Code": "consumer_code",
-    "Certification Body": "certification_body",
-}
 
 
 def rename_columns(cols: list) -> list:
@@ -275,7 +205,6 @@ def match_companies_house(company_name: str, api_key: str) -> pd.Series:
         return match_companies_house(company_name, api_key)
 
 
-# copied from process_mcs_utils.py and changed slightly
 def geocode_postcode(data: pd.DataFrame, geodata: pd.DataFrame) -> pd.DataFrame:
     """
     Updates data with latitude and longitude columns, by merging with geodata
@@ -295,6 +224,84 @@ def geocode_postcode(data: pd.DataFrame, geodata: pd.DataFrame) -> pd.DataFrame:
     )
 
     return data
+
+
+## ----- Legacy functions and variables below -----
+# The functions and variables below are legacy functions that are no longer in use.
+# Some of them are commented because they still exist but have been adapter
+colnames_dict = {
+    "Version Number": "version",
+    "Certificate Creation Date": "cert_date",
+    "Commissioning Date": "commission_date",
+    "Address Line 1": "address_1",
+    "Address Line 2": "address_2",
+    "Address Line 3": "address_3",
+    "County": "county",
+    "Postcode": "postcode",
+    "Local Authority": "local_authority",
+    "Total Installed Capacity": "capacity",
+    "Estimated Annual Generation": "estimated_annual_generation",
+    "Installation Company Name": "installer_name",
+    "Green Deal Installation?": "green_deal",
+    "Products": "products",
+    "Flow temp/SCOP ": "flow_scop",
+    "Technology Type": "tech_type",
+    "Installation Type": "installation_type",
+    " Installation Type": "installation_type",
+    "End User Installation Type": "end_user_installation_type",
+    "Installation New at Commissioning Date?": "new",
+    "Renewable System Design": "design",
+    "Annual Space Heating Demand": "heat_demand",
+    "Annual Water Heating Demand": "water_demand",
+    "Annual Space Heating Supplied": "heat_supplied",
+    "Annual Water Heating Supplied": "water_supplied",
+    "Installation Requires Metering?": "metering",
+    "RHI Metering Status": "rhi_status",
+    "RHI Metering Not Ready Reason": "rhi_not_ready",
+    "Number of MCS Certificates": "n_certificates",
+    "Heating System Type": "system_type",
+    "Alternative Heating System Type": "alt_type",
+    "Alternative Heating System Fuel Type": "alt_fuel",
+    "Overall Cost": "cost",
+    "Fuel Type": "fuel_type",
+    "Installation Company MCS Number": "installation_company_mcs_number",  # new var provided now in installations
+}
+
+mcs_companies_dict = {
+    "Company Name": "installer_name",
+    "MCS certificate number": "certificate_number",
+    "Add 1": "address_1",
+    "Add2": "address_2",
+    "Town": "town",
+    "County": "county",
+    "PCode": "postcode",
+    "Solar Thermal": "solar_thermal",
+    "Wind Turbines": "wind_turbines",
+    "Air Source Heat Pumps": "air_source_hps",
+    "Exhaust Air Heat Pumps": "exhaust_air_hps",
+    "Biomass": "biomass",
+    "Solar Photovoltaics": "solar_pv",
+    "Micro CHP": "micro_chp",
+    "Solar Assisted Heat Pump": "solar_assisted_hps",
+    "Gas Absorption Heat Pump": "gas_absorption_hps",
+    "Ground/Water Source Heat Pump": "ground_water_hps",
+    "Battery Storage": "battery_storage",
+    "Eastern Region": "eastern_region",
+    "East Midlands Region": "east_midlands_region",
+    "London Region": "london_region",
+    "North East Region": "north_east_region",
+    "North West Region": "north_west_region",
+    "South East Region": "south_east_region",
+    "South West Region": "south_west_region",
+    "West Midlands Region": "west_midlands_region",
+    "Yorkshire Humberside Region": "yorkshire_humberside_region",
+    "Northern Ireland Region": "northern_ireland_region",
+    "Scotland Region": "scotland_region",
+    "Wales Region": "wales_region",
+    "Effective From": "effective_from",
+    "Consumer Code": "consumer_code",
+    "Certification Body": "certification_body",
+}
 
 
 def clean_concat_installers(data):
@@ -344,7 +351,9 @@ def clean_concat_installers(data):
 
 
 def remove_punctuation(address):
-    """Remove all unwanted punctuation from an address.
+    """
+    ---Legacy function---
+    Remove all unwanted punctuation from an address.
     Underscores are kept and slashes/dashes are converted
     to underscores so that the numeric tokens in e.g.
     "Flat 3/2" and "Flat 3-2" are treated as a whole later.
@@ -369,7 +378,9 @@ def remove_punctuation(address):
 
 
 def extract_token_set(address, postcode, max_token_length):
-    """Extract valid numeric tokens from address string.
+    """
+    ---Legacy function---
+    Extract valid numeric tokens from address string.
     Numeric tokens are considered to be character strings containing numbers
     e.g. "45", "3a", "4_1".
     'Valid' is defined as
@@ -404,11 +415,11 @@ def extract_token_set(address, postcode, max_token_length):
     return valid_token_set
 
 
-## ----- Legacy functions below -----
-# The functions below were originally created by India and used to process the installers data we were receving
+# The functions and variables below were originally created by India and used to process the installers data we were receving
 # from MCS each quarter. Now that we are working with the historical table of installers, we had to change these
 # functions slighly as per above. We kept the original ones for reference, if we ever need to go back to them to
 # repeat any analysis.
+#
 # def clean_company_name(company_name):
 #    """cleans installation company name by:
 #        - removing "company" stopwords like ltd, limited;

--- a/asf_core_data/pipeline/mcs/process/process_mcs_utils.py
+++ b/asf_core_data/pipeline/mcs/process/process_mcs_utils.py
@@ -10,10 +10,7 @@ import requests
 import time
 import re
 import numpy as np
-
-from asf_core_data.getters.data_getters import load_s3_data
-
-from asf_core_data.config import base_config
+import random
 
 # %%
 
@@ -92,19 +89,42 @@ mcs_companies_dict = {
 }
 
 
-def clean_company_name(company_name):
-    """cleans installation company name by:
-        - removing "company" stopwords like ltd, limited;
-        - lowers company name
-        - removes punctuation
-    Args:
-        company_name (str): Name of company to clean.
-    Returns:
-        company_name (str): Cleaned company name.
+def rename_columns(cols: list) -> list:
     """
-    company_stopwords = ["ltd", "ltd.", "limited", "limited.", "old", "account", "t/a"]
+    Renames a list of strings, e.g. a list of column names, by:
+    - applying lower case;
+    - replacing "heat pump" by "hp";
+    - replacing " " and "/" by "_";
+    - correcting the word address.
 
-    company_name = company_name.lower().translate(str.maketrans("", "", "()-"))
+    Args:
+        cols: original column names
+    Returns:
+        Renamed column names
+    """
+    cols = [c.lower() for c in cols]
+    changes_dict = {"heat pump": "hp", " ": "_", "/": "_", "adddress": "address"}
+    for item in changes_dict.keys():
+        cols = [c.replace(item, changes_dict[item]) for c in cols]
+
+    return cols
+
+
+def clean_company_name(company_name: str) -> str:
+    """
+    Cleans installation company name by:
+        - changing company name to lower case;
+        - removing punctuation;
+        - removing company-related stopwords like "ltd", "limited", etc.;
+
+    Args:
+        company_name: Name of company to clean.
+    Returns:
+        company_name: Cleaned company name.
+    """
+    company_stopwords = ["ltd", "limited", "old", "account"]
+
+    company_name = company_name.lower().translate(str.maketrans("", "", "()-,/.&"))
     company_name = [
         comp for comp in company_name.split() if comp not in company_stopwords
     ]
@@ -112,8 +132,177 @@ def clean_company_name(company_name):
     return " ".join(company_name)
 
 
+def deal_with_versions_of_trading_as(installer_name: str) -> str:
+    """
+    Replaces several expressions representing "trading as" by the expression
+    "trading as" in the installer name.
+
+    Args:
+        installer_name: installer name
+
+    Returns:
+        updated installer name
+    """
+    versions = {
+        "t/a": "trading as",
+        " ta ": " trading as ",
+        "a trading name of": "trading as",
+        "the trading name of": "trading as",
+    }
+    for item in versions:
+        installer_name = installer_name.replace(item, versions[item])
+
+    return installer_name
+
+
+def from_list_to_dictionary(list_values: list) -> dict:
+    """
+    Transforms a list into a dictionary where each key is matched to the first
+    value in the list. Creates a mapping between each item in the list and the first one.
+    Arg:
+        list_values: a list of values e.g. ["Company A", "Company B", "Company A trading as Company B"]
+    Returns:
+        Dictionary mapping all values to the first one
+        e.g. {"Company B":"Company A", "Company A trading as Company B": "Company A"}
+    """
+    return {value: list_values[0] for value in list_values[1:]}
+
+
+def map_position_of_subset_items(list_of_strings: list) -> dict:
+    """
+    Returns a mapping between the position of strings in a list which are a subset of each other.
+    Example:
+    set_of_strings = ["company a ltd", "a ltd", "a"]
+    Outputs {0: 2, 1: 2}
+    Note that, in the example above, 0 is initially mapped to 1 but then that's overwritten by 0 being mapped to 2.
+
+    Args:
+        list_of_strings: a list of strings
+    Returns:
+        A dictionary mapping the position of strings that are subset of another.
+    """
+    return {
+        i: j
+        for i in range(len(list_of_strings) - 1)
+        for j in range(i + 1, len(list_of_strings), 1)
+        if (list_of_strings[i] in list_of_strings[j])
+        or (list_of_strings[j] in list_of_strings[i])
+    }
+
+
+def position_to_value(list_of_strings: list, indices_dict: dict) -> dict:
+    """
+    Returns dictionary resulting from mapping a dictionary with indices as key-value pairs to a list of strings.
+    Args:
+        list_of_strings: list of strings, e.g. ["a", "b", "c"]
+        indices_dict: dictionary of indices, e.g. {0:2, 1:2}
+    Returns:
+        The mapped dictionary e.g. {"a":"c", "b":"c"}
+
+    """
+    return {
+        list_of_strings[key]: list_of_strings[indices_dict[key]]
+        for key in indices_dict.keys()
+    }
+
+
+def match_companies_house(company_name: str, api_key: str) -> pd.Series:
+    """
+    Fuzzy match between MCS company name and Companies House API company names and
+    returns Companies House information: company full address and company date of creation.
+
+    Args:
+        company_name: Company name used to query company house API
+        api_key: API key to request data from live company house API endpoint
+    Returns:
+        company_info: pandas Series with 2 values, full address and creation date
+    """
+
+    # E.g. "Flo Group LTD T/A Flo Renewables" -> "flo renewables"
+    company_name = company_name.lower()
+    if "trading as" in company_name:
+        company_name = deal_with_versions_of_trading_as(company_name).split(
+            " trading as "
+        )[1]
+
+    # endpoint url
+    base_url = f"https://api.company-information.service.gov.uk/search/companies?q={company_name}"
+
+    response = requests.get(base_url, auth=(api_key, ""))
+
+    # developer guidelines state you can make 600 requests per 5 mins
+    # this translates into 1 request every 0.5 seconds
+    time.sleep(0.5)
+
+    response_status_code = response.status_code
+
+    if response_status_code == 200:  # status code 200 means all good with request
+        company_data = response.json()
+        if (
+            (company_data is not None)
+            and ("items" in company_data.keys())
+            and len(company_data["items"]) > 0
+        ):
+            address_snippet = (
+                company_data["items"][0]["address_snippet"]
+                if ("address_snippet" in company_data["items"][0].keys())
+                else None
+            )
+            date_of_creation = (
+                company_data["items"][0]["date_of_creation"]
+                if "date_of_creation" in company_data["items"][0].keys()
+                else None
+            )
+
+            return pd.Series([address_snippet, date_of_creation])
+
+        else:
+            return pd.Series([None, None])
+    else:
+        if response_status_code >= 400 and response_status_code < 500:
+            raise Exception(
+                "Cannot get data, the program will stop!\nHTTP {}: {}".format(
+                    response_status_code, response.text
+                )
+            )
+        sleep_seconds = random.randint(5, 60)
+        print(
+            "Cannot get data, your program will sleep for {} seconds...\nHTTP {}: {}".format(
+                sleep_seconds, response_status_code, response.text
+            )
+        )
+        time.sleep(sleep_seconds)
+        return match_companies_house(company_name, api_key)
+
+
+# copied from process_mcs_utils.py and changed slightly
+def geocode_postcode(data: pd.DataFrame, geodata: pd.DataFrame) -> pd.DataFrame:
+    """
+    Updates data with latitude and longitude columns, by merging with geodata
+    on postode column (left merge, not to loose any data).
+    Also transforms postcode column by removing the space.
+
+    Args:
+        data: DataFrame with postcode column.
+        geodata: DataFrame with postcode, latitude and longitude columns.
+    """
+
+    geodata["postcode"] = geodata["postcode"].str.replace(" ", "")
+
+    data["postcode"] = data["postcode"].str.upper().str.replace(" ", "")
+    data = data.merge(
+        geodata[["postcode", "latitude", "longitude"]], how="left", on="postcode"
+    )
+
+    return data
+
+
 def clean_concat_installers(data):
-    """Cleans concatenated installers data by:
+    """
+    Legacy function: only used for quarterly installers data,
+    not for historical installers.
+
+    Cleans concatenated installers data by:
         - dropping duplicate company names;
         - removing columns with identical values;
         - merging similar columns.
@@ -152,80 +341,6 @@ def clean_concat_installers(data):
     ]
 
     return data.reset_index(drop=True)
-
-
-def geocode_postcode(data, geodata):
-    """geocodes dataset with 'postcode' column.
-    Args:
-        data (pd.DataFrame): DataFrame with 'postcode' column.
-        geodata (pd.DataFrame): DataFrame with 'postcode', 'latitude' and 'longitude' columns.
-    Returns:
-        data_with_geodata (pd.DataFrame): Merged data DataFrame with 'latitude' and 'longitude'.
-    """
-
-    geodata["postcode"] = geodata["postcode"].str.replace(" ", "")
-
-    if "postcode" in data.columns:
-        data["postcode"] = data["postcode"].str.upper().str.replace(" ", "")
-        data_with_postcode = pd.merge(
-            data, geodata[["postcode", "latitude", "longitude"]], on="postcode"
-        )
-        print(
-            f"lost {len(list(set(data.postcode) - set(geodata.postcode)))} postcodes in merge."
-        )
-        return data_with_postcode
-    else:
-        print("'postcode' not found in data columns.")
-
-
-def match_companies_house(company_name, api_key):
-    """Fuzzy matches company name with company house API and
-        returns companies house information.
-    Args:
-        company_name (str): Company name to query company house API with.
-        api_key (str): Api key to call live company house API end point.
-    Returns:
-        company_info (dict): Dictionary of company house data associated to company name.
-    """
-
-    if len(company_name.split()) == 1:
-        company_name
-    else:
-        company_name = "+".join(company_name.split())
-
-    company_info = dict()
-    base_url = "https://api.company-information.service.gov.uk/search/companies?q={company_name}".format(
-        company_name=company_name
-    )
-    response = requests.get(base_url, auth=(api_key, ""))
-
-    if response.status_code == 200:
-        company_data = response.json()
-        if company_data is not None:
-            if "items" in company_data.keys():
-                if company_data["items"] != []:
-                    closest_match = company_data["items"][
-                        0
-                    ]  # closest match according to companies house API
-
-                    company_info[company_name.replace("+", " ")] = {
-                        "company_number": closest_match["company_number"],
-                        "title": closest_match["title"],
-                        "company_status": closest_match["company_status"],
-                        "description_identifier": closest_match[
-                            "description_identifier"
-                        ],
-                        "address_snippet": closest_match["address_snippet"],
-                    }
-        return company_info
-
-    elif response.status_code == 429:
-        print(f"{response.status_code} error! Sleeping for 5 mins...")
-        time.sleep(
-            301
-        )  # sleep for 5 minutes as developer guidelines state you can make 600 requests per 5 mins
-    else:
-        print(f"{response.status_code} error!")
 
 
 def remove_punctuation(address):
@@ -289,19 +404,100 @@ def extract_token_set(address, postcode, max_token_length):
     return valid_token_set
 
 
-# %%
-
-if __name__ == "__main__":
-    installer_company_data_path = base_config.MCS_RAW_INSTALLER_CONCAT_S3_PATH
-    uk_geo_path = base_config.POSTCODE_TO_COORD_PATH
-    cleaned_installations_path = base_config.PREPROC_GEO_MCS_INSTALLATIONS_PATH
-    cleaned_installer_company_path = base_config.PREPROC_MCS_INSTALLER_COMPANY_PATH
-    bucket_name = base_config.BUCKET_NAME
-
-    installer_company_data = load_s3_data(bucket_name, installer_company_data_path)
-    uk_geo_data = load_s3_data(bucket_name, uk_geo_path)
-
-    ## preprocess different columns
-    installer_company_data = clean_concat_installers(
-        installer_company_data
-    ).reset_index(drop=True)
+## ----- Legacy functions below -----
+# The functions below were originally created by India and used to process the installers data we were receving
+# from MCS each quarter. Now that we are working with the historical table of installers, we had to change these
+# functions slighly as per above. We kept the original ones for reference, if we ever need to go back to them to
+# repeat any analysis.
+# def clean_company_name(company_name):
+#    """cleans installation company name by:
+#        - removing "company" stopwords like ltd, limited;
+#        - lowers company name
+#        - removes punctuation
+#    Args:
+#        company_name (str): Name of company to clean.
+#    Returns:
+#        company_name (str): Cleaned company name.
+#    """
+#    company_stopwords = ["ltd", "ltd.", "limited", "limited.", "old", "account", "t/a"]
+#
+#    company_name = company_name.lower().translate(str.maketrans("", "", "()-"))
+#    company_name = [
+#        comp for comp in company_name.split() if comp not in company_stopwords
+#    ]
+#
+#    return " ".join(company_name)
+#
+#
+# def geocode_postcode(data, geodata):
+#    """geocodes dataset with 'postcode' column.
+#    Args:
+#        data (pd.DataFrame): DataFrame with 'postcode' column.
+#        geodata (pd.DataFrame): DataFrame with 'postcode', 'latitude' and 'longitude' columns.
+#    Returns:
+#        data_with_geodata (pd.DataFrame): Merged data DataFrame with 'latitude' and 'longitude'.
+#    """
+#
+#    geodata["postcode"] = geodata["postcode"].str.replace(" ", "")
+#
+#    if "postcode" in data.columns:
+#        data["postcode"] = data["postcode"].str.upper().str.replace(" ", "")
+#        data_with_postcode = pd.merge(
+#            data, geodata[["postcode", "latitude", "longitude"]], on="postcode"
+#        )
+#        print(
+#            f"lost {len(list(set(data.postcode) - set(geodata.postcode)))} postcodes in merge."
+#        )
+#        return data_with_postcode
+#    else:
+#        print("'postcode' not found in data columns.")
+#
+#
+# def match_companies_house(company_name, api_key):
+#    """Fuzzy matches company name with company house API and
+#        returns companies house information.
+#    Args:
+#        company_name (str): Company name to query company house API with.
+#        api_key (str): Api key to call live company house API end point.
+#    Returns:
+#        company_info (dict): Dictionary of company house data associated to company name.
+#    """
+#
+#    if len(company_name.split()) == 1:
+#        company_name
+#    else:
+#        company_name = "+".join(company_name.split())
+#
+#    company_info = dict()
+#    base_url = "https://api.company-information.service.gov.uk/search/companies?q={company_name}".format(
+#        company_name=company_name
+#    )
+#    response = requests.get(base_url, auth=(api_key, ""))
+#
+#    if response.status_code == 200:
+#        company_data = response.json()
+#        if company_data is not None:
+#            if "items" in company_data.keys():
+#                if company_data["items"] != []:
+#                    closest_match = company_data["items"][
+#                        0
+#                    ]  # closest match according to companies house API
+#
+#                    company_info[company_name.replace("+", " ")] = {
+#                        "company_number": closest_match["company_number"],
+#                        "title": closest_match["title"],
+#                        "company_status": closest_match["company_status"],
+#                        "description_identifier": closest_match[
+#                            "description_identifier"
+#                        ],
+#                        "address_snippet": closest_match["address_snippet"],
+#                    }
+#        return company_info
+#
+#    elif response.status_code == 429:
+#        print(f"{response.status_code} error! Sleeping for 5 mins...")
+#        time.sleep(
+#            301
+#        )  # sleep for 5 minutes as developer guidelines state you can make 600 requests per 5 mins
+#    else:
+#        print(f"{response.status_code} error!")

--- a/asf_core_data/pipeline/mcs/process/process_mcs_utils.py
+++ b/asf_core_data/pipeline/mcs/process/process_mcs_utils.py
@@ -52,6 +52,7 @@ colnames_dict = {
     "Alternative Heating System Fuel Type": "alt_fuel",
     "Overall Cost": "cost",
     "Fuel Type": "fuel_type",
+    "Installation Company MCS Number": "installation_company_mcs_number",  # new var provided now in installations
 }
 
 mcs_companies_dict = {

--- a/asf_core_data/pipeline/mcs/test/test_process_historical_mcs_installers.py
+++ b/asf_core_data/pipeline/mcs/test/test_process_historical_mcs_installers.py
@@ -1,0 +1,303 @@
+"""
+Script to test the data processing pipeline for raw historical MCS installers data.
+"""
+
+import pytest
+import numpy as np
+import pandas as pd
+from datetime import datetime
+import os
+from asf_core_data.pipeline.mcs.process.process_historical_mcs_installers import (
+    rename_columns,
+    deal_with_versions_of_trading_as,
+    match_companies_house,
+    clean_company_name,
+    from_list_to_dictionary,
+    dictionary_mapping_trading_as_company_names,
+    map_position_of_subset_items,
+    position_to_value,
+    basic_preprocessing_of_installations,
+)
+from asf_core_data.getters.mcs_getters.get_mcs_installers import (
+    get_processed_historical_installers_data,
+    get_raw_historical_mcs_installers,
+)
+from asf_core_data.getters.mcs_getters.get_mcs_installations import (
+    get_raw_historical_installations_data,
+)
+
+
+raw_installers_data = get_raw_historical_mcs_installers(
+    "raw_historical_mcs_installers_20230207.xlsx"
+)
+processed_installers_data = get_processed_historical_installers_data("20230207")
+
+
+def test_rename_columns():
+    """
+    Testing rename_columns() function.
+    """
+    cols = ["My Column", "ADDDRESS 3", "G/WS heat pump"]
+    cols = rename_columns(cols)
+
+    assert cols == ["my_column", "address_3", "g_ws_hp"]
+
+
+def test_join_installation_and_design_vars():
+    """
+    Testing join_installation_and_design_vars() function.
+    """
+
+    processed_data = processed_installers_data[
+        ~processed_installers_data["original_record"]
+    ]
+
+    installation_cols = [
+        col for col in raw_installers_data.columns if "installation" in col
+    ]
+
+    for col in installation_cols:
+        processed_col = col.replace("installation_", "")
+        assert len(raw_installers_data[pd.isnull(raw_installers_data[col])]) >= len(
+            processed_data[pd.isnull(processed_data[processed_col])]
+        )
+        design_var = col.replace("installation", "design")
+        assert len(
+            raw_installers_data[pd.isnull(raw_installers_data[design_var])]
+        ) >= len(processed_data[pd.isnull(processed_data[processed_col])])
+
+
+def test_deal_with_versions_of_trading_as():
+    """
+    Testing deal_with_versions_of_trading_as() function.
+    """
+
+    names = [
+        "A t/a B",
+        "C ta D",
+        "Eta F",
+        "G a trading name of H",
+        "I the trading name of J",
+        "A ta B t/a C the trading name of D the trading name of E",
+    ]
+
+    new_names = []
+    for n in names:
+        new_names.append(deal_with_versions_of_trading_as(n))
+
+    assert new_names == [
+        "A trading as B",
+        "C trading as D",
+        "Eta F",
+        "G trading as H",
+        "I trading as J",
+        "A trading as B trading as C trading as D trading as E",
+    ]
+
+
+def test_match_companies_house():
+    """
+    Get result for the data we know and see accuracy.
+    """
+
+    data = processed_installers_data[processed_installers_data["original_record"]]
+    data = data[data["effective_to"] >= datetime.today()]
+    # data = data[data["effective_from"]>=datetime(2021,1,1)]
+    data = data[["company_name", "postcode"]]
+    # data = data.sample(n=50)
+
+    data[["full_address", "date_of_creation"]] = data.apply(
+        lambda x: match_companies_house(
+            x["company_name"], os.environ.get("COMPANIES_HOUSE_API_KEY")
+        ),
+        axis=1,
+    )
+
+    data["postcode_companies_house"] = (
+        data["full_address"]
+        .apply(lambda x: x.split(",")[-1].strip() if x is not None else None)
+        .str.upper()
+        .str.replace(" ", "")
+    )
+
+    assert (
+        len(data[data["postcode"] != data["postcode_companies_house"]]) / len(data)
+        < 0.1
+    )
+
+
+def test_recompute_full_address():
+    """
+    Test if the recompute_full_address() function works as expected.
+    """
+
+    data = processed_installers_data[~processed_installers_data["original_record"]]
+
+    fraction = len(data[~pd.isnull(data["full_address"])]) / len(data)
+
+    assert fraction > 0
+
+
+def test_get_missing_installers_info():
+    """
+    Test if the test_get_missing_installers_info() function works as expected.
+    """
+
+    data = processed_installers_data[~processed_installers_data["original_record"]]
+
+    assert len(data) > 0
+
+
+def test_update_full_address():
+    """
+    Test if the update_full_address() function works as expected.
+    """
+
+    data = processed_installers_data[
+        ~pd.isnull(processed_installers_data["full_address"])
+    ]
+
+    assert len(data[data["full_address"].str.contains(",nan")]) == 0
+
+
+def test_create_certified_flags():
+    """
+    Test if the create_certified_flags() function works as expected.
+    """
+
+    data = processed_installers_data.copy()
+
+    certified_flags = [col for col in data.columns if "certified" in col]
+
+    for col in certified_flags:
+        start_date_col = col.replace("certified", "start_date")
+        assert len(data[data[col]]) == len(data[~pd.isnull(data[start_date_col])])
+        assert len(set(data[col].unique()).intersection([True, False])) == 2
+
+
+def test_clean_company_name():
+    """
+    Test if the clean_company_name() function works as expected.
+    """
+
+    company_name = "COMPANY & A (old/ account) ltd ltd. limited limited."
+    assert clean_company_name(company_name) == "company a"
+
+
+def test_from_list_to_dictionary():
+    """
+    Test if the from_list_to_dictionary() function works as expected.
+    """
+
+    l = ["Company A", "Company B", "Company A trading as Company B"]
+
+    assert from_list_to_dictionary(l) == {
+        "Company B": "Company A",
+        "Company A trading as Company B": "Company A",
+    }
+
+
+def test_dictionary_mapping_trading_as_company_names():
+    """
+    Test if the dictionary_mapping_trading_as_company_names() function works as expected.
+    """
+
+    test_df = pd.DataFrame(columns=["processed_company_name"])
+    test_df["processed_company_name"] = ["a trading as b", "c trading as d"]
+
+    assert dictionary_mapping_trading_as_company_names(test_df) == {
+        "b": "a",
+        "a trading as b": "a",
+        "d": "c",
+        "c trading as d": "c",
+    }
+
+
+def test_map_position_of_subset_items():
+    """
+    Test if the map_position_of_subset_items() function works as expected.
+    """
+
+    l = ["company a ltd", "a ltd", "a"]
+
+    assert map_position_of_subset_items(l) == {0: 2, 1: 2}
+
+
+def test_position_to_value():
+    """
+    Test if the position_to_value() function works as expected.
+    """
+
+    l = ["a", "b", "c"]
+    d = {0: 2, 1: 2}
+
+    assert position_to_value(l, d) == {"a": "c", "b": "c"}
+
+
+def test_map_installers_same_location_different_id():
+    """
+    Test if the map_installers_same_location_different_id() function works as expected.
+    """
+
+    assert list(
+        processed_installers_data.groupby(["postcode", "address_1"])
+        .nunique()["company_unique_id"]
+        .unique()
+    ) == [1]
+
+
+def test_create_installer_unique_id():
+    """
+    Test if the create_installer_unique_id() function works as expected.
+    """
+
+    data = get_processed_historical_installers_data("20230207")
+
+    assert len(data[pd.isnull(data["company_unique_id"])]) == 0
+
+
+def test_geocode_postcode():
+    """
+    Test if the geocode_postcode() function works as expected.
+    """
+
+    processed_data = processed_installers_data[
+        ~processed_installers_data["original_record"]
+    ]
+
+    fraction_missing = len(processed_data[pd.isnull(processed_data["postcode"])]) / len(
+        processed_data
+    )
+
+    assert fraction_missing < 0.3
+
+
+def test_add_certification_body_info():
+    """
+    Test if the add_certification_body_info() function works as expected.
+    """
+
+    raw_installations = get_raw_historical_installations_data(
+        "raw_historical_mcs_installations_20230119.xlsx"
+    )
+    basic_preprocessing_of_installations(raw_installations)
+
+    cb_installations = set(raw_installations["certification_body"].unique())
+    cb_installers = set(
+        processed_installers_data[
+            ~pd.isnull(processed_installers_data["certification_body"])
+        ]["certification_body"].unique()
+    )
+
+    assert cb_installers.issubset(cb_installations)
+
+
+def test_preprocess_historical_installers():
+    """
+    Test if the preprocess_historical_installers() function works as expected.
+    """
+    processed_data = processed_installers_data[
+        processed_installers_data["original_record"]
+    ]
+
+    assert len(raw_installers_data.drop_duplicates()) == len(processed_data)

--- a/asf_core_data/pipeline/mcs/test/test_process_historical_mcs_installers.py
+++ b/asf_core_data/pipeline/mcs/test/test_process_historical_mcs_installers.py
@@ -18,18 +18,16 @@ from asf_core_data.pipeline.mcs.process.process_historical_mcs_installers import
     basic_preprocessing_of_installations,
 )
 from asf_core_data.getters.mcs_getters.get_mcs_installers import (
-    get_processed_historical_installers_data,
-    get_raw_historical_mcs_installers,
+    get_most_recent_processed_historical_installers_data,
+    get_most_recent_raw_historical_installers_data,
 )
 from asf_core_data.getters.mcs_getters.get_mcs_installations import (
     get_raw_historical_installations_data,
 )
 
 
-raw_installers_data = get_raw_historical_mcs_installers(
-    "raw_historical_mcs_installers_20230207.xlsx"
-)
-processed_installers_data = get_processed_historical_installers_data("20230207")
+raw_installers_data = get_most_recent_raw_historical_installers_data()
+processed_installers_data = get_most_recent_processed_historical_installers_data()
 
 
 def test_rename_columns():
@@ -279,9 +277,14 @@ def test_create_installer_unique_id():
     by checking that the company unique ID is never missing.
     """
 
-    data = get_processed_historical_installers_data("20230207")
-
-    assert len(data[pd.isnull(data["company_unique_id"])]) == 0
+    assert (
+        len(
+            processed_installers_data[
+                pd.isnull(processed_installers_data["company_unique_id"])
+            ]
+        )
+        == 0
+    )
 
 
 def test_geocode_postcode():

--- a/asf_core_data/pipeline/mcs/test/test_process_mcs_installations.py
+++ b/asf_core_data/pipeline/mcs/test/test_process_mcs_installations.py
@@ -1,0 +1,21 @@
+"""
+Script to test the data processing pipeline for MCS installations data.
+"""
+
+import pytest
+import pandas as pd
+from asf_core_data.pipeline.mcs.process.process_mcs_installations import (
+    get_processed_installations_data,
+)
+
+
+def test_company_unique_id_is_added():
+    """
+    Test whether the company unique ID is successfully added to the installations table
+    and that there are no missing values.
+    """
+    data = get_processed_installations_data(refresh=True)
+
+    assert "company_unique_id" in data.columns
+
+    assert len(data[pd.isnull(data["company_unique_id"])]) == 0

--- a/asf_core_data/pipeline/mcs/test/test_process_mcs_installations.py
+++ b/asf_core_data/pipeline/mcs/test/test_process_mcs_installations.py
@@ -3,10 +3,60 @@ Script to test the data processing pipeline for MCS installations data.
 """
 
 import pytest
+import re
 import pandas as pd
 from asf_core_data.pipeline.mcs.process.process_mcs_installations import (
     get_processed_installations_data,
 )
+from asf_core_data.getters.mcs_getters.get_mcs_installations import (
+    get_most_recent_raw_historical_installations_data,
+)
+
+processed_installations = get_processed_installations_data()
+raw_installations = get_most_recent_raw_historical_installations_data()
+
+
+def test_raw_columns_exist():
+    """
+    Checks if raw columns are as expected.
+    """
+
+    expected_cols = {
+        "Version Number",
+        "Commissioning Date",
+        "Address Line 1",
+        "Address Line 2",
+        "Address Line 3",
+        "County",
+        "Postcode",
+        "Local Authority",
+        "Total Installed Capacity",
+        "Green Deal Installation?",
+        "Installation Company Name",
+        "Products",
+        "Technology Type",
+        "Renewable System Design",
+        "Annual Space Heating Demand",
+        "Annual Water Heating Demand",
+        "Annual Space Heating Supplied",
+        "Annual Water Heating Supplied",
+        "Installation Requires Metering?",
+        "RHI Metering Status",
+        "RHI Metering Not Ready Reason",
+        "Number of MCS Certificates",
+        "Heating System Type",
+        "Fuel Type",
+        "Overall Cost",
+        "Installation Type",
+        "Installation Company MCS Number",
+    }
+    existing_cols = raw_installations.columns
+
+    assert len(expected_cols.intersection(existing_cols)) == len(expected_cols)
+
+    assert len([col for col in existing_cols if col not in expected_cols]) == 0
+
+    assert len([col for col in expected_cols if col not in existing_cols]) == 0
 
 
 def test_company_unique_id_is_added():
@@ -14,8 +64,56 @@ def test_company_unique_id_is_added():
     Test whether the company unique ID is successfully added to the installations table
     and that there are no missing values.
     """
-    data = get_processed_installations_data(refresh=True)
+    assert "company_unique_id" in processed_installations.columns
 
-    assert "company_unique_id" in data.columns
+    assert (
+        len(
+            processed_installations[
+                pd.isnull(processed_installations["company_unique_id"])
+            ]
+        )
+        == 0
+    )
 
-    assert len(data[pd.isnull(data["company_unique_id"])]) == 0
+
+def test_regex_extraction_works():
+    """
+    Check if regex in add_hp_features() is working.
+    """
+
+    product_regex_dict = {
+        "product_id": "MCS Product Number: ([^|]+)",
+        "product_name": "Product Name: ([^|]+)",
+        "manufacturer": "License Holder: ([^|]+)",
+        "flow_temp": "Flow Temp: ([^|]+)",
+        "scop": "SCOP: ([^)]+)",
+    }
+    product = "(ID: 1234 | MCS Product Number: abc 1-7 xx | Product Name: + 1-7 xx | License Holder: ABC XYZ, S.L. | Flow Temp: 50 | SCOP: 3.91)"
+    results_dict = dict()
+    for product_feat, regex in product_regex_dict.items():
+        results_dict[product_feat] = re.search(regex, product).group(1).strip()
+
+    assert results_dict == {
+        "product_id": "abc 1-7 xx",
+        "product_name": "+ 1-7 xx",
+        "manufacturer": "ABC XYZ, S.L.",
+        "flow_temp": "50",
+        "scop": "3.91",
+    }
+
+
+def test_same_lines_before_after():
+    """
+    Checks if raw and processed datasets have the same number of lines.
+    """
+    assert len(raw_installations) == len(processed_installations)
+
+
+def test_no_duplicate_lines():
+    """
+    Checks that there are no duplicate lines in either raw or processed datasets
+    """
+    assert len(raw_installations.drop_duplicates()) == len(raw_installations)
+    assert len(processed_installations.drop_duplicates()) == len(
+        processed_installations
+    )


### PR DESCRIPTION
# Description 

This PR:
- creates a processing pipeline for historical MCS installers data;
- creates getters to retrieve raw historical installers and installations data from S3 (I've added the data manually to S3, to `asf-core-data/inputs/MCS/latest_raw_data/historical/` - had to create a folder for historical data within `latest_raw_data`, otherwise it would have messed the work in `generate_mcs_data.py` because of the file names);
- adds the company unique ID to the installations data in the processing installations pipeline;
- creates tests for the processing pipeline;
- I've also added a notebook (`asf_core_data/analysis/historical_installers.ipynb`) if you want to take a look at raw data and processed data, while reviewing the code, to better understand the changes.

closes #31 
closes #45

# Instructions for Reviewer(s)

Hey @ch-williamson, @athrado and @sqr00t thanks so much for taking the time to look at this PR.
- Chris and Julia, it would be great if at least one of you could check the files run, but more than that, check if all makes sense within the asf_core_data data processing pipeline and that the additions/changes don't have potential for messing something else up :) as a follow-up we should probably add a few tests that are automatically run by github actions.
- Solomon, it would be great if you could check if the general "flow" looks good to you/makes sense and if any changes are needed before the code gets transferred to asf_daps. Note that, the historical installers data needs to have a pair of variables as table primary key: `(company_unique_id, mcs_certificate_number)`
- Julia, I didn't add code to create a merged version of the data (for HPMT consumption) that includes the installers, as I didn't have time to familiarise enough with `mcs_epc_joining.py` and `merge_install_dates.py` scripts, to integrate these changes somewhere in the code. But hopefully it shouldn't be too difficult. All that needs to be done is an outer merge between processed installers and installations. Happy to do that after I'm back, or for you to do it if you would prefer.

## Setup
- Create a developer account for Companies House API (it's super quick to set up, but the confirmation email might take a few minutes to arrive, maybe about 10-15min):
   1. Register for an account [here](https://developer.company-information.service.gov.uk/get-started);
   2. Create a new application [here](https://developer.company-information.service.gov.uk/manage-applications/add). Give it any name and description you want and choose the Live environment.
   3.  Copy your API key credentials.
- clone this repo: `git clone git@github.com:nestauk/asf_core_data.git`
- checkout to the correct branch: `git checkout 31_historical_MCS_installers_data`
- Run `make install`;
- Run `direnv allow`;
- Activate the conda enviroment: `conda activate asf_core_data`;
- Set your API credentials as environment variable, i.e run `export COMPANIES_HOUSE_API_KEY="ADD_YOUR_API_KEY_HERE"` in the command line and replace `ADD_YOUR_API_KEY_HERE` with your API key credentials.

## Review
Could you run the following script to check if it works for you?
`python3 asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py`
A file will be saved to S3 and replace the one I have previously created (absolutely no problem with that, feel free to run!). It gives a warning, `SettingWithCopyWarning`, but all should run fine and a file should be saved to S3: `asf-core-data/outputs/MCS/installers/mcs_historical_installers_20230207.csv`

There's a script to test the functions I created. Could you please check if 17 out 18 tests pass? Should take approximately 2 mins to run.
`pytest asf_core_data/pipeline/mcs/test/test_process_historical_mcs_installers.py`
One of the tests fails, the one testing the data coming from Companies House - it doesn't mean that the function is not doing what's supposed to do. It just means that 1) the accuracy of the matching is low or 2) the matching is good but the data is incorrect in one of the sources (when comparing postcode data coming from MCS to Companies House data). I've manually checked some of the values and it seems that sometimes Companies House has the correct postcode, other times the correct postcode is in MCS data. But I need to take a further look at this!
Also please feel free to suggest other tests.

I would also ask you to review the remaining scripts with changes, with a bigger focus on: 
- `asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py`
- The additions made to `asf_core_data/pipeline/mcs/process/process_mcs_installations.py` - is this a good place to add the "company_unique_id" var to the installations? Or maybe it should be added to `generate_mcs_data.py`?

A few questions:
- Shall we keep the postcode with the space or without?
- Does the general pre-processing pipeline for historical installers make sense? Any suggestions for simplification/to improve readability?

Thanks a lot!

---

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [ ] I have explained the feature in this PR or (better) in `output/reports/`
- [x] I have requested a code review
