### PR TITLE
Enhancements to CONSTRUCTION_AGE_BAND, not allowing for unknowns in UPRN and fix heating features

### DIFF
--- a/asf_core_data/getters/epc/epc_data.py
+++ b/asf_core_data/getters/epc/epc_data.py
@@ -677,24 +677,26 @@ def filter_by_year(
         epc_df = epc_df.sort_values("INSPECTION_DATE", ascending=True)
 
         # Dealing with EPC entries with missing UPRN
-        uprn_missing = epc_df[pd.isnull(epc_df["UPRN"])]
+        uprn_missing = epc_df[pd.isnull(epc_df[building_identifier])]
         uprn_missing = uprn_missing.drop_duplicates(
             subset=["ADDRESS1", "ADDRESS2", "POSTCODE"], keep=selection_dict[selection]
-        ).sort_index()
+        )
 
         # Dealing with EPC entries with known UPRN
-        epc_df = epc_df[~pd.isnull(epc_df["UPRN"])]
+        epc_df = epc_df[~pd.isnull(epc_df[building_identifier])]
         epc_df = epc_df.drop_duplicates(
             subset=[building_identifier], keep=selection_dict[selection]
-        ).sort_index()
+        )
 
         # Concatenating datasets together and sorting by inspection_date again
         epc_df = pd.concat([epc_df, uprn_missing])
         epc_df = epc_df.sort_values("INSPECTION_DATE", ascending=True)
 
-    elif selection is None:
-        epc_df = epc_df
+        epc_df.reset_index(drop=True, inplace=True)
 
+    elif selection is None:
+        epc_df = epc_df.sort_values("INSPECTION_DATE", ascending=True)
+        epc_df.reset_index(drop=True, inplace=True)
     else:
         raise IOError("{} not implemented.".format(selection))
 

--- a/asf_core_data/pipeline/preprocessing/data_cleaning.py
+++ b/asf_core_data/pipeline/preprocessing/data_cleaning.py
@@ -76,6 +76,9 @@ import numpy as np
 from asf_core_data import PROJECT_DIR, get_yaml_config, Path
 from asf_core_data.config import base_config
 from asf_core_data.pipeline.preprocessing import data_cleaning_utils
+from asf_core_data.pipeline.preprocessing.feature_engineering import (
+    enhance_construction_age_band,
+)
 
 # ---------------------------------------------------------------------------------
 
@@ -267,7 +270,6 @@ def create_efficiency_mapping(efficiency_set, only_first=base_config.ONLY_FIRST_
     efficiency_map = {}
 
     for eff in efficiency_set:
-
         # If efficiency is float (incl. NaN)
         if isinstance(eff, float):
             efficiency_map[eff] = np.nan
@@ -314,7 +316,6 @@ def clean_EFF_SCORES(df):
     for feat in df.columns:
         # If efficiency feature, get respective mapping
         if feat.endswith("_EFF"):
-
             df[feat] = df[feat].str.lower()
             map_dict = create_efficiency_mapping(list(df[feat].unique()))
 
@@ -373,7 +374,6 @@ def standardise_dates(
     ]
 
     for feature in date_features:
-
         # Fix years starting with 00 -> 20..
         df[feature] = (
             df[feature].astype(str).str.replace(r"00(\d\d)", r"20\1", regex=True)
@@ -401,11 +401,13 @@ def standardise_unknowns(df):
         pandas.DataFrame: Dataframe with cleaned up unknown values.
     """
     for feat in df.columns:
-
         if feat in data_cleaning_utils.numeric_features:
             df[feat] = df[feat].replace(data_cleaning_utils.invalid_values, np.nan)
         else:
-            df[feat] = df[feat].replace(data_cleaning_utils.invalid_values, "unknown")
+            if feat != "UPRN":
+                df[feat] = df[feat].replace(
+                    data_cleaning_utils.invalid_values, "unknown"
+                )
 
     return df
 
@@ -421,9 +423,7 @@ def standardise_features(df):
     """
 
     for feat in df.columns:
-
         if feat in data_cleaning_utils.features_to_standardise:
-
             df[feat] = df[feat].str.strip()
             feat_clean_dict = data_cleaning_utils.feature_cleaning_dict[feat]
 
@@ -486,7 +486,6 @@ def custom_clean_features(df, cap_features=False):
     # [Additional cleaning functions here]
 
     if cap_features:
-
         cap_value_dict = {
             "NUMBER_HABITABLE_ROOMS": 10,
             "NUMBER_HEATED_ROOMS": 10,
@@ -517,6 +516,16 @@ def clean_epc_data(df):
     df = standardise_features(df)
     df = standardise_dates(df)
     df = custom_clean_features(df)
+
+    df["CONSTRUCTION_AGE_BAND"] = df.apply(
+        lambda x: enhance_construction_age_band(
+            x["CONSTRUCTION_AGE_BAND"],
+            x["TRANSACTION_TYPE"],
+            x["INSPECTION_DATE"],
+            x["COUNTRY"],
+        ),
+        axis=1,
+    )
 
     return df
 

--- a/asf_core_data/pipeline/preprocessing/data_cleaning.py
+++ b/asf_core_data/pipeline/preprocessing/data_cleaning.py
@@ -519,10 +519,7 @@ def clean_epc_data(df):
 
     df["CONSTRUCTION_AGE_BAND"] = df.apply(
         lambda x: enhance_construction_age_band(
-            x["CONSTRUCTION_AGE_BAND"],
-            x["TRANSACTION_TYPE"],
-            x["INSPECTION_DATE"],
-            x["COUNTRY"],
+            x["CONSTRUCTION_AGE_BAND"], x["TRANSACTION_TYPE"]
         ),
         axis=1,
     )

--- a/asf_core_data/pipeline/preprocessing/feature_engineering.py
+++ b/asf_core_data/pipeline/preprocessing/feature_engineering.py
@@ -25,6 +25,24 @@ from datetime import datetime
 
 # ----------------------------------------------------------------------------------
 
+other_heating_system = [
+    "boiler and radiator",
+    "boiler and underfloor",
+    "community scheme",
+    "heater",  # not specified heater
+]
+
+other_hp_expressions = [
+    "heat pump",
+    "pumpa teas",
+    "pwmp gwres",  # starts with p
+    "bwmp gwres",  # different from above, starts with b
+    "pympiau gwres",  # starts with p
+    "bympiau gwres",  # different from above, starts with b
+]
+
+# ----------------------------------------------------------------------------------
+
 
 def short_hash(text):
     """Generate a unique short hash for given string.
@@ -198,26 +216,8 @@ def get_heating_system(mainheat_description: str) -> str:
     if pd.isnull(mainheat_description):
         return "unknown"
     else:
-        system_type = "unknown"
-
         heating = mainheat_description.lower()
         heating = heating.replace(" & ", " and ")
-
-        other_heating_system = [
-            "boiler and radiator",
-            "boiler and underfloor",
-            "community scheme",
-            "heater",  # not specified heater
-        ]
-
-        other_hp_expressions = [
-            "heat pump",
-            "pumpa teas",
-            "pwmp gwres",
-            "bwmp gwres",
-            "pympiau gwres",
-            "bympiau gwres",
-        ]
 
         if ("ground source heat pump" in heating) or (
             "ground sourceheat pump" in heating
@@ -256,7 +256,7 @@ def get_heating_system(mainheat_description: str) -> str:
                 if word in heating:
                     return word
 
-        return system_type
+        return "unknown"
 
 
 def get_heating_fuel(mainheat_description: str) -> str:
@@ -271,26 +271,8 @@ def get_heating_fuel(mainheat_description: str) -> str:
     if pd.isnull(mainheat_description):
         return "unknown"
     else:
-        source_type = "unknown"
-
         heating = mainheat_description.lower()
         heating = heating.replace(" & ", " and ")
-
-        other_heating_system = [
-            "boiler and radiator",
-            "boiler and underfloor",
-            "community scheme",
-            "heater",  # not specified heater
-        ]
-
-        other_hp_expressions = [
-            "heat pump",
-            "pumpa teas",
-            "pwmp gwres",
-            "bwmp gwres",
-            "pympiau gwres",
-            "bympiau gwres",
-        ]
 
         if ("ground source heat pump" in heating) or (
             "ground sourceheat pump" in heating
@@ -332,7 +314,7 @@ def get_heating_fuel(mainheat_description: str) -> str:
                 if word in heating:
                     return source
 
-    return source_type
+    return "unknown"
 
 
 def get_heating_features(df, fine_grained_HP_types=False):
@@ -462,53 +444,20 @@ def get_building_entry_feature(df, feature):
 def enhance_construction_age_band(
     construction_age_band: str,
     transaction_type: str,
-    inspection_date: str,
-    country: str,
 ) -> str:
     """
-    Enhances construction age band by replacing unknown when transaction type is new dwelling and
-    inspection date is known.
+    Enhances construction age band by replacing unknown when transaction type is new dwelling
+    (EPC inspections only began in 2008, so if it's a new dwelling then the age band will be "2007 onwards").
 
     Args:
         construction_age_band: property's construction age band
         transaction_type: transaction type (e.g. new dwelling)
-        inspection_date: inspection date as a string
-        country: country (Scotland, England or Wales)
-
     Retruns:
         Updated construction age band
     """
     if construction_age_band == "unknown":
         if transaction_type == "new dwelling":
-            if ~pd.isnull(inspection_date) and (inspection_date is not None):
-                # inspection_year = datetime.strptime(inspection_date, "%Y-%m-%d").year
-                inspection_year = inspection_date.year
-                if inspection_year >= 2007:
-                    return "2007 onwards"
-                elif inspection_year >= 2003:
-                    return "2003-2007"
-                elif inspection_year >= 1996:
-                    return "1996-2002"
-                elif inspection_year >= 1991:
-                    return "1991-1998"
-                elif inspection_year >= 1983:
-                    return "1983-1991"
-                elif inspection_year >= 1976:
-                    return "1976-1983"
-                elif inspection_year >= 1965:
-                    return "1965-1975"
-                elif inspection_year >= 1950:
-                    return "1950-1966"
-                elif inspection_year >= 1930:
-                    return "1930-1949"
-                elif inspection_year >= 1919:
-                    return "1900-1929"
-                elif (inspection_year >= 1900) and (country != "Scotland"):
-                    return "1900-1929"
-                elif (inspection_year < 1900) and (country != "Scotland"):
-                    return "England and Wales: before 1900"
-                elif (inspection_year <= 1919) and (country == "Scotland"):
-                    return "Scotland: before 1919"
+            return "2007 onwards"
     return construction_age_band
 
 


### PR DESCRIPTION
# Description 

This PR fixes the following issues in the EPC processing pipeline:
- #71: with the changes we're not allowing for `UPRN` column to take the `“unknown”` value when missing (as it can be misleading since this is an identifier). We also fixed an existing bug when dropping duplicates (when creating `EPC_processed_and_deduplicated.csv`): previously, all EPC entries with `UPRN` missing where considered to be the same property when dropping duplicates, although they in fact represent multiple properties. I tried a temporary fix for this bug, so that when `UPRN` is missing, we now use `ADDRESS1`, `ADDRESS2` and `POSTCODE` to drop duplicates (there might be a better way to this!). It still needs to be fixed further as per issue #72, but that’ll be for a next PR (ideally, we would have a true unique identifier for properties and use it when dropping duplicates). Changes live in `feature_engineering.py` and `epc_data.py`
- #68: currently this variable has approximately 10% missing values. We enhance it by filling the missing values with inspection year if transaction type is “new dwelling”. With this enhancement, missing values decreases to 1%. Changes live in `feature_engineering.py` and `data_cleaning.py`. 
    - Maybe instead of having the `enhance_construction_age_band()` call in `clean_epc_data()` in line 520 maybe it could be called in `clean_CONSTRUCTION_AGE_BAND()` in line 158 – any strong feelings?
    - Can you double check the else if’s in `enhance_construction_age_band()` make sense? I am only wondering about the last ones which depend on `COUNTRY` (I don’t think the year needs to be in the if statement at that point, but I left it there since it helps with readability).
- #70: the `get_heating_features()` function in `feature_engineering.py` had a bug. We fix this bug (by allowing for `None`’s to be treated as `NaN`s) and improve the function by removing the for loop and using `.apply()` and `np.where()` – this speeds up the processing pipeline by a few minutes and improves code readability. I double checked the processed data before and after this change and a few values in the variables created by this function are different. The reason is that sometimes `MAINHEAT_DESCRIPTION` contains multiple applicable values (e.g. “gas” and “electric” for `HEATING_FUEL`) and depending on the order by which we check the presence of these in `MAINHEAT_DESCRIPTION`, we either return one or the other. This is something we should fix in the future (issue #73) by:
    - Considering all the applicable values (e.g. `HEATING_FUEL`=”gas and electric”, `HEATING_SYSTEM`=”boiler and radiators and underfloor heating“);
    - Or by only considering the main value (e.g. main heating fuel for the property is gas, so we consider gas, although the house also has electric heaters);

closes #68
closes #70
closes #71

# Instructions for Reviewer(s)

## Review

Dear @ch-williamson ,

It would be great if you could review the changes to the following scripts:
- `asf_core_data/pipeline/preprocessing/feature_engineering.py`
- `asf_core_data/pipeline/preprocessing/data_cleaning.py`
- `asf_core_data/getters/epc/epc_data.py`

@sqr00t / @Jack-Vines  - tagging you FYI

## Setup

In case you want/need to run anything:
- clone this repo: `git clone git@github.com:nestauk/asf_core_data.git`
- checkout to the correct branch: `git checkout 70_issue_feature_engineeringpy`
- Run `make install`;
- Run `direnv allow`;
- Activate the conda enviroment: `conda activate asf_core_data`;

---

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [ ] I have checked the code runs
- [ ] I have tested the code
- [ ] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [ ] I have explained the feature in this PR or (better) in `output/reports/`
- [ ] I have requested a code review
