### PR TITLE
Enhancing installer effective_to

### DIFF
--- a/asf_core_data/pipeline/data_joining/merge_proc_datasets.py
+++ b/asf_core_data/pipeline/data_joining/merge_proc_datasets.py
@@ -177,9 +177,6 @@ def add_mcs_installer_data(
         usecols = list(set(usecols + ["company_unique_id", "company_name"]))
 
     newest_hist_inst_batch = data_batches.get_latest_hist_installers()
-    # extracts "20230207" from "mcs_historical_installers_20230207.csv"
-    date = newest_hist_inst_batch.split("_")[-1].split(".csv")[0]
-    date = str(datetime.strptime(date, "%Y%m%d").date())
 
     # Load MCS
     mcs_instllr_data = data_getters.load_s3_data(
@@ -187,15 +184,6 @@ def add_mcs_installer_data(
     )
 
     mcs_instllr_data.rename(columns={"postcode": "POSTCODE"}, inplace=True)
-
-    # when effective_from is non missing and effective_to is missing, it means the certification hasn't ended
-    # so we fill it with the data when the data was received
-    mcs_instllr_data["effective_to"] = np.where(
-        mcs_instllr_data["effective_to"].isna()
-        & ~mcs_instllr_data["effective_from"].isna(),
-        date,
-        mcs_instllr_data["effective_to"],
-    )
 
     merged_df = df.merge(
         right=mcs_instllr_data,

--- a/asf_core_data/pipeline/mcs/generate_mcs_data.py
+++ b/asf_core_data/pipeline/mcs/generate_mcs_data.py
@@ -101,14 +101,6 @@ def generate_and_save_mcs(
     all_installations_data = get_most_recent_raw_historical_installations_data()
     all_installers_data = get_most_recent_raw_historical_installers_data()
 
-    # process historical installers (needs to happen before processing historical installations)
-    processed_historical_installers = preprocess_historical_installers(
-        raw_historical_installers=all_installers_data,
-        raw_historical_installations=all_installations_data,
-        geographical_data=uk_geo_data,
-        companies_house_api_key=companies_house_api_key,
-    )
-
     # save historical installers
     date_historical_installers_received = get_most_recent_batch_name(
         bucket=bucket_name,
@@ -118,6 +110,15 @@ def generate_and_save_mcs(
     date_historical_installers_received = date_historical_installers_received.split(
         "installers_"
     )[1].split(".xlsx")[0]
+
+    # process historical installers (needs to happen before processing historical installations)
+    processed_historical_installers = preprocess_historical_installers(
+        date_data_shared=date_historical_installers_received,
+        raw_historical_installers=all_installers_data,
+        raw_historical_installations=all_installations_data,
+        geographical_data=uk_geo_data,
+        companies_house_api_key=companies_house_api_key,
+    )
 
     installers_path = (
         base_config.PREPROCESSED_MCS_HISTORICAL_INSTALLERS_FILE_PATH.format(

--- a/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
+++ b/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
@@ -561,7 +561,7 @@ def get_max_date(date_1: datetime, date_2: datetime) -> datetime:
         return max(date_1, date_2)
 
 
-def update_effective_to_data(
+def update_effective_to_date(
     date_data_shared: str,
     installer_data: pd.DataFrame,
     installations_data: pd.DataFrame,
@@ -710,7 +710,7 @@ def preprocess_historical_installers(
     # Create installer unique ID
     create_installer_unique_id(raw_historical_installers)
 
-    raw_historical_installers = update_effective_to_data(
+    raw_historical_installers = update_effective_to_date(
         date_data_shared, raw_historical_installers, raw_historical_installations
     )
 

--- a/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
+++ b/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
@@ -42,6 +42,7 @@ from datetime import datetime
 from argparse import ArgumentParser
 from asf_core_data.config import base_config
 from asf_core_data.getters.data_getters import load_s3_data, save_to_s3
+from asf_core_data.getters.epc import data_batches
 from asf_core_data.getters.mcs_getters.get_mcs_installers import (
     get_raw_historical_installers_data,
 )
@@ -543,7 +544,78 @@ def add_certification_body_info(
     return installer_data
 
 
+def get_max_date(date_1: datetime, date_2: datetime) -> datetime:
+    """
+    Gets max date between two dates.
+    Args:
+        date1: date
+        date2: date
+    Returns:
+        Max date
+    """
+    if pd.isnull(date_2):
+        return date_1
+    elif pd.isnull(date_1):
+        return date_2
+    else:
+        return max(date_1, date_2)
+
+
+def update_effective_to_data(
+    date_data_shared: str,
+    installer_data: pd.DataFrame,
+    installations_data: pd.DataFrame,
+) -> pd.DataFrame:
+    """
+    Updates effective_to date:
+    - when effective_from is non missing and effective_to is missing, it means the certification hasn't ended
+    so we fill it with the data when the data was received;
+    - then, if effective_to happens before the last commissioning date, we update effective_to with the last commisioning date
+
+    Args:
+        date_data_shared: str following the pattern "YYYYMMDD"
+        installer_data: installer data
+        installations_data: installations data
+    Returns:
+        Updated installer data.
+    """
+    date = datetime.strptime(date_data_shared, "%Y%m%d").date()
+
+    installer_data["effective_to"] = installer_data.apply(
+        lambda x: date
+        if pd.isnull(x["effective_to"]) and ~pd.isnull(["effective_from"])
+        else x["effective_to"],
+        axis=1,
+    )
+
+    installations_match_vars = [
+        "installation_company_name",
+        "installation_company_mcs_number",
+    ]
+    installers_match_vars = ["company_name", "mcs_certificate_number"]
+
+    last_commissioning_date = installations_data.groupby(
+        installations_match_vars, as_index=False
+    )[["commissioning_date"]].max()
+
+    installer_data = installer_data.merge(
+        right=last_commissioning_date,
+        how="left",
+        left_on=installers_match_vars,
+        right_on=installations_match_vars,
+    )
+
+    installer_data["effective_to"] = installer_data.apply(
+        lambda x: get_max_date(x["effective_to"], x["commissioning_date"]), axis=1
+    )
+
+    installer_data.drop(columns="commissioning_date", inplace=True)
+
+    return installer_data
+
+
 def preprocess_historical_installers(
+    date_data_shared: str,
     raw_historical_installers: pd.DataFrame,
     raw_historical_installations: pd.DataFrame,
     geographical_data: pd.DataFrame,
@@ -562,6 +634,7 @@ def preprocess_historical_installers(
     - Creating a variable that uniquely identifies installers.
 
     Args:
+        date_data_shared: date when raw historical installers data was shared
         raw_historical_installers: raw historical installers data
         raw_historical_installations: raw historical installations data
         geographical_data: geographical data with postcode, latitude and longitude information
@@ -637,6 +710,10 @@ def preprocess_historical_installers(
     # Create installer unique ID
     create_installer_unique_id(raw_historical_installers)
 
+    raw_historical_installers = update_effective_to_data(
+        date_data_shared, raw_historical_installers, raw_historical_installations
+    )
+
     return raw_historical_installers[
         base_config.processed_historical_installers_columns_order
     ]
@@ -692,8 +769,14 @@ if __name__ == "__main__":
         args.raw_historical_installations_filename
     )
 
+    # date when data was shared by MCS in MCS data dumps
+    date = args.raw_historical_installers_filename.split("installers_")[1].split(
+        ".xlsx"
+    )[0]
+
     # Process raw historical installers data
     processed_historical_installers = preprocess_historical_installers(
+        date_data_shared=date,
         raw_historical_installers=raw_historical_installers,
         raw_historical_installations=raw_historical_installations,
         geographical_data=uk_geo_data,
@@ -702,10 +785,6 @@ if __name__ == "__main__":
 
     # Saving processed data to S3
     processed_data_path = base_config.PREPROCESSED_MCS_HISTORICAL_INSTALLERS_FILE_PATH
-    # date when data was shared by MCS in MCS data dumps
-    date = args.raw_historical_installers_filename.split("installers_")[1].split(
-        ".xlsx"
-    )[0]
 
     save_to_s3(
         s3_bucket_name,


### PR DESCRIPTION
# Description 

This PR fixes issue #69 which relates to installer certification dates (`effective_to` is the installer certification end date and `effective_from` is the installer certification start date):
- When `effective_from` is non-missing and `effective_to` is missing, it means that the certification hasn’t ended (that's how the data comes, as raw). Before this PR, we were filling these missing values with the _date_ the data was sent by MCS (which was our best guess). This processing lived in `merge_proc_datasets.py` (the script that creates an outer merge between EPC, MCS installations and MCS installers for the HPMT project), but I now moved it these changes to `process_historical_mcs_installers.py`, where we process installer data, which makes more sense;
- Additionally, I am also enhancing `effective_to` so that we check whether `effective_to` date happens before the last `commissioning_date` for each pair (installer, certification number). If so, then the last commissioning date is actually a better guess for `effective_to` than the date MCS sent us the installer data. This change is being applied to all data, not only when effective_to is initially missing. In a number of cases (small %), we are actually changing the `effective_to` date when it wasn’t initially missing. Is it possible for a heat pump to be commissioned after the certification has ended? Might this be a typo in `effective_to` or shouldn’t we be changing the values of `effective_to` in the first place when the value is not missing? I could have this enhancement only for originally missing values. Let me know what you think :)

closes #69 

# Instructions for Reviewer(s)

## Review

Dear @ch-williamson,

It would be great if you could double check these changes make sense and double check the changes to scripts:
- `asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py`
- `asf_core_data/pipeline/mcs/generate_mcs_data.py`
- `asf_core_data/pipeline/data_joining/merge_proc_datasets.py`

@sqr00t / @Jack-Vines  - tagging you FYI

## Setup

In case you want/need to run anything:
- clone this repo: `git clone git@github.com:nestauk/asf_core_data.git`
- checkout to the correct branch: `git checkout 69_improvements_installer_effective_to`
- Run `make install`;
- Run `direnv allow`;
- Activate the conda enviroment: `conda activate asf_core_data`;
- Set your API credentials as environment variable, i.e run `export COMPANIES_HOUSE_API_KEY="ADD_YOUR_API_KEY_HERE"` in the command line and replace `ADD_YOUR_API_KEY_HERE` with your API key credentials.

---

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [ ] I have checked the code runs
- [ ] I have tested the code
- [ ] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [ ] I have explained the feature in this PR or (better) in `output/reports/`
- [ ] I have requested a code review
