### PR TITLE
Dealing with false positives in unique ID

### DIFF
--- a/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
+++ b/asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py
@@ -478,21 +478,25 @@ def create_installer_unique_id(installer_data: pd.DataFrame):
     # Dropping processed_company_name as no longer needed
     installer_data.drop("processed_company_name", axis=1, inplace=True)
 
+    ## -------------------------------------------------------------------------------
+    ## We commented the code below since it was leading to false positives in unique id
+    ## but we'll keep it here in case ever needed again
+    ## -------------------------------------------------------------------------------
     # Companies have the same location but not currently identified as being the same
-    same_postcode_no_match = installer_data.groupby("postcode", as_index=False)[
-        ["company_unique_id"]
-    ].nunique()
-    same_postcode_no_match = same_postcode_no_match[
-        same_postcode_no_match["company_unique_id"] > 1
-    ]["postcode"].unique()
+    # same_postcode_no_match = installer_data.groupby("postcode", as_index=False)[
+    #    ["company_unique_id"]
+    # ].nunique()
+    # same_postcode_no_match = same_postcode_no_match[
+    #    same_postcode_no_match["company_unique_id"] > 1
+    # ]["postcode"].unique()
 
     # New unique ID matches based on companies with same location
-    new_matches = map_installers_same_location_different_id(
-        same_postcode_no_match, installer_data
-    )
-    installer_data["company_unique_id"] = installer_data["company_unique_id"].apply(
-        lambda x: new_matches[x] if x in new_matches.keys() else x
-    )
+    # new_matches = map_installers_same_location_different_id(
+    #    same_postcode_no_match, installer_data
+    # )
+    # installer_data["company_unique_id"] = installer_data["company_unique_id"].apply(
+    #    lambda x: new_matches[x] if x in new_matches.keys() else x
+    # )
 
 
 def add_certification_body_info(


### PR DESCRIPTION
# Description 

This PR fixes issue #64 which relates to installer unique ID. Might be useful to read the comments in the issue page.

closes #64

# Instructions for Reviewer(s)

## Review

Hey @sqr00t could you please double check things still look good after the changes in `asf_core_data/pipeline/mcs/process/process_historical_mcs_installers.py`? Many thanks!

## Setup

In case you want/need to run anything:
- clone this repo: `git clone git@github.com:nestauk/asf_core_data.git`
- checkout to the correct branch: `git checkout 64_accuracy_installers_unique_id`
- Run `make install`;
- Run `direnv allow`;
- Activate the conda enviroment: `conda activate asf_core_data`;
- Set your API credentials as environment variable, i.e run `export COMPANIES_HOUSE_API_KEY="ADD_YOUR_API_KEY_HERE"` in the command line and replace `ADD_YOUR_API_KEY_HERE` with your API key credentials.

---