### PR TITLE
Processing MCS installation type

### DIFF
--- a/asf_core_data/pipeline/mcs/process/process_mcs_installations.py
+++ b/asf_core_data/pipeline/mcs/process/process_mcs_installations.py
@@ -79,6 +79,25 @@ def mask_outliers(hps, max_cost=base_config.MCS_MAX_COST):
     return hps
 
 
+def process_installation_type(installations: pd.DataFrame) -> pd.DataFrame:
+    """
+    Joins together the info from installation_type and end_user_installation_type
+    as the two variables represent the same thing.
+
+    Args:
+        installations: MCS installations data
+    Return:
+        Installations data with updated installation type.
+    """
+    installations["installation_type"] = installations["installation_type"].fillna(
+        installations["end_user_installation_type"]
+    )
+
+    installations.drop("end_user_installation_type", inplace=True)
+
+    return installations
+
+
 def identify_clusters(hps, time_interval=base_config.MCS_CLUSTER_TIME_INTERVAL):
     """Label HP records with whether they form part of a 'cluster'
     of installations in the same postcode and around the same time.
@@ -162,6 +181,7 @@ def get_processed_installations_data():
 
     installations_data = add_hp_features(installations_data)
     installations_data = mask_outliers(installations_data)
+    installations_data = process_installation_type(installations_data)
     installations_data = identify_clusters(installations_data)
 
     # getting latest batch of processed historical installers data

--- a/asf_core_data/pipeline/mcs/process/process_mcs_installations.py
+++ b/asf_core_data/pipeline/mcs/process/process_mcs_installations.py
@@ -79,10 +79,9 @@ def mask_outliers(hps, max_cost=base_config.MCS_MAX_COST):
     return hps
 
 
-def process_installation_type(installations: pd.DataFrame) -> pd.DataFrame:
+def fill_missing_installation_type(installations: pd.DataFrame) -> pd.DataFrame:
     """
-    Joins together the info from installation_type and end_user_installation_type
-    as the two variables represent the same thing.
+    Fills missing installation_type with end_user_installation_type.
 
     Args:
         installations: MCS installations data
@@ -181,7 +180,7 @@ def get_processed_installations_data():
 
     installations_data = add_hp_features(installations_data)
     installations_data = mask_outliers(installations_data)
-    installations_data = process_installation_type(installations_data)
+    installations_data = fill_missing_installation_type(installations_data)
     installations_data = identify_clusters(installations_data)
 
     # getting latest batch of processed historical installers data

--- a/asf_core_data/pipeline/mcs/process/process_mcs_installations.py
+++ b/asf_core_data/pipeline/mcs/process/process_mcs_installations.py
@@ -91,8 +91,7 @@ def fill_missing_installation_type(installations: pd.DataFrame) -> pd.DataFrame:
     installations["installation_type"] = installations["installation_type"].fillna(
         installations["end_user_installation_type"]
     )
-
-    installations.drop("end_user_installation_type", inplace=True)
+    installations.drop(columns="end_user_installation_type", inplace=True)
 
     return installations
 


### PR DESCRIPTION
# Description 

This PR fixes issue #77 which joins together MCS `installation_type` and `end_user_installation_type` variables.

closes #77

# Instructions for Reviewer(s)

## Review

Hey @sqr00t - Can you please double check the changes in `asf_core_data/pipeline/mcs/process/process_mcs_installations.py` look good? Thanks!

---