### PR TITLE
Removing commercial installations from merged dataset and moving function due to circular import

### DIFF
--- a/asf_core_data/config/base_config.py
+++ b/asf_core_data/config/base_config.py
@@ -489,14 +489,14 @@ england_wales_only_features = [
 ]
 
 scotland_field_fix_dict = {
-    "BUILDING_REFERENCE_NUMBER": "Property_UPRN",
+    "BUILDING_REFERENCE_NUMBER": "ï»¿Property_UPRN",
     "UPRN": "OSG_UPRN",
     "POSTCODE": "Postcode",
     "INSPECTION_DATE": "Date of Assessment",
     "LODGEMENT_DATE": "Date of Certificate",
-    "ENERGY_CONSUMPTION_CURRENT": "Primary Energy Indicator (kWh/m²/year)",
-    "TOTAL_FLOOR_AREA": "Total floor area (m²)",
-    "CO2_EMISS_CURR_PER_FLOOR_AREA": "CO2 Emissions Current Per Floor Area (kg.CO2/m²/yr)",
+    "ENERGY_CONSUMPTION_CURRENT": "Primary Energy Indicator (kWh/mÂ²/year)",
+    "TOTAL_FLOOR_AREA": "Total floor area (mÂ²)",
+    "CO2_EMISS_CURR_PER_FLOOR_AREA": "CO2 Emissions Current Per Floor Area (kg.CO2/mÂ²/yr)",
     "CURRENT_ENERGY_EFFICIENCY": "Current energy efficiency rating",
     "CURRENT_ENERGY_RATING": "Current energy efficiency rating band",
     "POTENTIAL_ENERGY_EFFICIENCY": "Potential Energy Efficiency Rating",

--- a/asf_core_data/config/base_config.py
+++ b/asf_core_data/config/base_config.py
@@ -489,14 +489,14 @@ england_wales_only_features = [
 ]
 
 scotland_field_fix_dict = {
-    "BUILDING_REFERENCE_NUMBER": "ï»¿Property_UPRN",
+    "BUILDING_REFERENCE_NUMBER": "Property_UPRN",
     "UPRN": "OSG_UPRN",
     "POSTCODE": "Postcode",
     "INSPECTION_DATE": "Date of Assessment",
     "LODGEMENT_DATE": "Date of Certificate",
-    "ENERGY_CONSUMPTION_CURRENT": "Primary Energy Indicator (kWh/mÂ²/year)",
-    "TOTAL_FLOOR_AREA": "Total floor area (mÂ²)",
-    "CO2_EMISS_CURR_PER_FLOOR_AREA": "CO2 Emissions Current Per Floor Area (kg.CO2/mÂ²/yr)",
+    "ENERGY_CONSUMPTION_CURRENT": "Primary Energy Indicator (kWh/m²/year)",
+    "TOTAL_FLOOR_AREA": "Total floor area (m²)",
+    "CO2_EMISS_CURR_PER_FLOOR_AREA": "CO2 Emissions Current Per Floor Area (kg.CO2/m²/yr)",
     "CURRENT_ENERGY_EFFICIENCY": "Current energy efficiency rating",
     "CURRENT_ENERGY_RATING": "Current energy efficiency rating band",
     "POTENTIAL_ENERGY_EFFICIENCY": "Potential Energy Efficiency Rating",
@@ -675,6 +675,7 @@ MCS_INSTALLATIONS_FEAT_SELECTION_MERGED_DATASET = [
     "estimated_annual_generation",
     "flow_temp",
     "tech_type",
+    "installation_type",
     "scop",
     "design",
     "product_name",

--- a/asf_core_data/pipeline/data_joining/merge_proc_datasets.py
+++ b/asf_core_data/pipeline/data_joining/merge_proc_datasets.py
@@ -24,9 +24,9 @@ from argparse import ArgumentParser
 from datetime import date
 import pandas as pd
 import numpy as np
-from datetime import datetime
-from asf_core_data.pipeline.preprocessing import feature_engineering
-from asf_core_data.getters import data_getters
+from asf_core_data.pipeline.preprocessing.feature_engineering import (
+    get_postcode_coordinates,
+)
 
 # ---------------------------------------------------------------------------------
 
@@ -68,7 +68,9 @@ def add_mcs_installations_data(
     )
 
     # Removing commercial installations
-    mcs_df = mcs_df[~mcs_df["installation_type"].str.contains("commercial", case=False)]
+    mcs_df = mcs_df[
+        ~mcs_df["installation_type"].str.contains("commercial", case=False, na=False)
+    ]
 
     mcs_df = install_date_computation.reformat_mcs_date(mcs_df, "commission_date")
     mcs_df.rename(columns={"postcode": "POSTCODE"}, inplace=True)
@@ -251,9 +253,7 @@ def merging_pipeline(
     merged_data = add_mcs_installer_data(merged_data, usecols=mcs_installers_usecols)
 
     # Add coordinates for EPC data
-    merged_data = feature_engineering.get_postcode_coordinates(
-        merged_data, postcode_field_name="POSTCODE"
-    )
+    merged_data = get_postcode_coordinates(merged_data, postcode_field_name="POSTCODE")
 
     today = date.today().strftime("%y%m%d")
 

--- a/asf_core_data/pipeline/data_joining/merge_proc_datasets.py
+++ b/asf_core_data/pipeline/data_joining/merge_proc_datasets.py
@@ -68,7 +68,7 @@ def add_mcs_installations_data(
     )
 
     # Removing commercial installations
-    mcs_df = mcs_df[mcs_df["installation_type"] != "Commercial"]
+    mcs_df = mcs_df[~mcs_df["installation_type"].str.contains("commercial", case=False)]
 
     mcs_df = install_date_computation.reformat_mcs_date(mcs_df, "commission_date")
     mcs_df.rename(columns={"postcode": "POSTCODE"}, inplace=True)

--- a/asf_core_data/pipeline/data_joining/merge_proc_datasets.py
+++ b/asf_core_data/pipeline/data_joining/merge_proc_datasets.py
@@ -42,6 +42,7 @@ def add_mcs_installations_data(
     - Load MCS installations data (most relevant fields)
     - Mark matches in data (MCS_AVAILABLE, EPC_AVAILABLE)
     - Join based on UPRN, otherwise concatenate
+    - Remove commercial installations
     - Standardise fields such as HP_INSTALLED or HP_TYPE
 
     Args:
@@ -65,6 +66,11 @@ def add_mcs_installations_data(
         usecols=usecols,
         dtype={"UPRN": "str", "commission_date": "str"},
     )
+
+    # Removing commercial installations
+    print("bf remv com inst:", len(mcs_df))
+    mcs_df = mcs_df[mcs_df["installation_type"] != "Commercial"]
+    print("af remv com inst:", len(mcs_df))
 
     mcs_df = install_date_computation.reformat_mcs_date(mcs_df, "commission_date")
     mcs_df.rename(columns={"postcode": "POSTCODE"}, inplace=True)

--- a/asf_core_data/pipeline/data_joining/merge_proc_datasets.py
+++ b/asf_core_data/pipeline/data_joining/merge_proc_datasets.py
@@ -68,9 +68,7 @@ def add_mcs_installations_data(
     )
 
     # Removing commercial installations
-    print("bf remv com inst:", len(mcs_df))
     mcs_df = mcs_df[mcs_df["installation_type"] != "Commercial"]
-    print("af remv com inst:", len(mcs_df))
 
     mcs_df = install_date_computation.reformat_mcs_date(mcs_df, "commission_date")
     mcs_df.rename(columns={"postcode": "POSTCODE"}, inplace=True)

--- a/asf_core_data/pipeline/preprocessing/data_cleaning.py
+++ b/asf_core_data/pipeline/preprocessing/data_cleaning.py
@@ -76,9 +76,6 @@ import numpy as np
 from asf_core_data import PROJECT_DIR, get_yaml_config, Path
 from asf_core_data.config import base_config
 from asf_core_data.pipeline.preprocessing import data_cleaning_utils
-from asf_core_data.pipeline.preprocessing.feature_engineering import (
-    enhance_construction_age_band,
-)
 
 # ---------------------------------------------------------------------------------
 
@@ -497,6 +494,26 @@ def custom_clean_features(df, cap_features=False):
                 df = cap_feature_values(df, feat, cap_value=cap_value_dict[feat])
 
     return df
+
+
+def enhance_construction_age_band(
+    construction_age_band: str,
+    transaction_type: str,
+) -> str:
+    """
+    Enhances construction age band by replacing unknown when transaction type is new dwelling
+    (EPC inspections only began in 2008, so if it's a new dwelling then the age band will be "2007 onwards").
+
+    Args:
+        construction_age_band: property's construction age band
+        transaction_type: transaction type (e.g. new dwelling)
+    Retruns:
+        Updated construction age band
+    """
+    if construction_age_band == "unknown":
+        if transaction_type == "new dwelling":
+            return "2007 onwards"
+    return construction_age_band
 
 
 def clean_epc_data(df):

--- a/asf_core_data/pipeline/preprocessing/feature_engineering.py
+++ b/asf_core_data/pipeline/preprocessing/feature_engineering.py
@@ -20,8 +20,7 @@ import numpy as np
 from hashlib import md5
 
 from asf_core_data.getters.supplementary_data.geospatial import coordinates
-from asf_core_data.pipeline.preprocessing import data_cleaning
-from datetime import datetime
+from asf_core_data.pipeline.preprocessing.data_cleaning import reformat_postcode
 
 # ----------------------------------------------------------------------------------
 
@@ -397,12 +396,12 @@ def get_postcode_coordinates(df, postcode_field_name="POSTCODE"):
     )
 
     # Reformat POSTCODE
-    postcode_coordinates_df = data_cleaning.reformat_postcode(
+    postcode_coordinates_df = reformat_postcode(
         postcode_coordinates_df,
         postcode_var_name=postcode_field_name,
         white_space="remove",
     )
-    df = data_cleaning.reformat_postcode(df, white_space="remove")
+    df = reformat_postcode(df, white_space="remove")
 
     # Merge with location data
     df = pd.merge(df, postcode_coordinates_df, on=postcode_field_name, how="left")

--- a/asf_core_data/pipeline/preprocessing/feature_engineering.py
+++ b/asf_core_data/pipeline/preprocessing/feature_engineering.py
@@ -441,26 +441,6 @@ def get_building_entry_feature(df, feature):
     return df
 
 
-def enhance_construction_age_band(
-    construction_age_band: str,
-    transaction_type: str,
-) -> str:
-    """
-    Enhances construction age band by replacing unknown when transaction type is new dwelling
-    (EPC inspections only began in 2008, so if it's a new dwelling then the age band will be "2007 onwards").
-
-    Args:
-        construction_age_band: property's construction age band
-        transaction_type: transaction type (e.g. new dwelling)
-    Retruns:
-        Updated construction age band
-    """
-    if construction_age_band == "unknown":
-        if transaction_type == "new dwelling":
-            return "2007 onwards"
-    return construction_age_band
-
-
 def get_additional_features(df):
     """Add new features to the EPC dataset.
     The new features include information about the inspection and entry date,


### PR DESCRIPTION
# Description 

This PR fixes:
- #78: by removing `Commercial` installations from the merged dataset for HPMT, since we're only focusing on `Domestic` installations. Rather than filtering to only keep `Domestic` installations, we filter `Commercial` installations out, so a small percentage of records has missing installation type. I also left the `installation_type` variable in the merged dataset so that the DV/PD team can have the ability to filter records with missing `installation_type`, if they need to.
- #83: by moving the function from `asf_core_data/pipeline/preprocessing/feature_engineering.py` to `asf_core_data/pipeline/preprocessing/data_cleaning.py`. This wasn't giving problems when running some scripts, but it was leading to problems when running `asf_core_data/pipeline/data_joining/merge_proc_datasets.py`.

closes #78 
closes #83 

# Instructions for Reviewer(s)

## Review

Hey @sqr00t , could you please review the scripts with changes? Shouldn't take long. Thanks so much!

## Setup
In case you want/need to run anything:

- clone this repo: `git clone git@github.com:nestauk/asf_core_data.git`
- checkout to the correct branch: `git checkout 78_remove_commercial_installations_hpmt`
- Run `make install`;
- Run `direnv allow`;
- Activate the conda enviroment: `conda activate asf_core_data`;
- Set your API credentials as environment variable, i.e run `export COMPANIES_HOUSE_API_KEY="ADD_YOUR_API_KEY_HERE"` in the command line and replace `ADD_YOUR_API_KEY_HERE` with your API key credentials.

---