### PR TITLE
Enhance UPRN and fix loading for Scotland data

### DIFF
--- a/asf_core_data/config/base_config.py
+++ b/asf_core_data/config/base_config.py
@@ -489,14 +489,14 @@ england_wales_only_features = [
 ]
 
 scotland_field_fix_dict = {
-    "BUILDING_REFERENCE_NUMBER": "ï»¿Property_UPRN",
+    "BUILDING_REFERENCE_NUMBER": "Property_UPRN",
     "UPRN": "OSG_UPRN",
     "POSTCODE": "Postcode",
     "INSPECTION_DATE": "Date of Assessment",
     "LODGEMENT_DATE": "Date of Certificate",
-    "ENERGY_CONSUMPTION_CURRENT": "Primary Energy Indicator (kWh/mÂ²/year)",
-    "TOTAL_FLOOR_AREA": "Total floor area (mÂ²)",
-    "CO2_EMISS_CURR_PER_FLOOR_AREA": "CO2 Emissions Current Per Floor Area (kg.CO2/mÂ²/yr)",
+    "ENERGY_CONSUMPTION_CURRENT": "Primary Energy Indicator (kWh/m²/year)",
+    "TOTAL_FLOOR_AREA": "Total floor area (m²)",
+    "CO2_EMISS_CURR_PER_FLOOR_AREA": "CO2 Emissions Current Per Floor Area (kg.CO2/m²/yr)",
     "CURRENT_ENERGY_EFFICIENCY": "Current energy efficiency rating",
     "CURRENT_ENERGY_RATING": "Current energy efficiency rating band",
     "POTENTIAL_ENERGY_EFFICIENCY": "Potential Energy Efficiency Rating",

--- a/asf_core_data/getters/epc/epc_data.py
+++ b/asf_core_data/getters/epc/epc_data.py
@@ -357,9 +357,6 @@ def load_england_wales_data(
     if add_country_f:
         epc_certs["COUNTRY"] = subset
 
-    if "UPRN" in epc_certs.columns and "BUILDING_REFERENCE_NUMBER" in epc_certs.columns:
-        epc_certs["UPRN"].fillna(epc_certs.BUILDING_REFERENCE_NUMBER, inplace=True)
-
     if batch in base_config.v0_batches and (
         usecols is None or "BUILDING_REFERENCE_NUMBER" in usecols
     ):

--- a/asf_core_data/getters/epc/epc_data.py
+++ b/asf_core_data/getters/epc/epc_data.py
@@ -185,8 +185,8 @@ def load_scotland_data(
             dtype=dtype,
             low_memory=low_memory,
             usecols=scot_usecols,
-            skiprows=skiprows,  # don't load first row (more ellaborate feature names),
-            encoding="latin-1",
+            skiprows=1,  # don't load first row (more ellaborate feature names),
+            # encoding="latin-1",
         )
         for file in files
     ]

--- a/asf_core_data/pipeline/preprocessing/feature_engineering.py
+++ b/asf_core_data/pipeline/preprocessing/feature_engineering.py
@@ -21,6 +21,7 @@ from hashlib import md5
 
 from asf_core_data.getters.supplementary_data.geospatial import coordinates
 from asf_core_data.pipeline.preprocessing.data_cleaning import reformat_postcode
+from asf_core_data.pipeline.mcs.process.process_mcs_utils import remove_punctuation
 
 # ----------------------------------------------------------------------------------
 
@@ -41,6 +42,106 @@ other_hp_expressions = [
 ]
 
 # ----------------------------------------------------------------------------------
+
+
+def prepare_address_data(address_1: str, address_2: str, postcode: str) -> str:
+    """
+    Prepares address and postcode information by removing removing punctuation,
+    removing leading and trailing whitespace and standardising postcodes.
+
+    Args:
+        address_1: first line of address (e.g. "Flat 1")
+        address_2: second line of address (e.g. "ABC road")
+        postcode: full postcode (e.g. "AB2 Y8X")
+
+
+    Returns:
+        A string with processed address_1, address_2 and postcode information,
+        e.g. "flat 1 abc road_AB2Y8X"
+    """
+    address_1 = remove_punctuation(address_1).lower().strip()
+    address_2 = remove_punctuation(address_2).lower().strip()
+    postcode = postcode.upper().replace(" ", "")
+
+    address_info = (address_1 + " " + address_2).strip()
+
+    return "_".join([address_info, postcode])
+
+
+def concatenate_building_with_address_info(
+    building_reference: str, address_info: str
+) -> str:
+    """
+    Concatenates building reference number with address information.
+
+    Args:
+        building_reference: building reference number, e.g. 1234
+        address_info: address information, e.g. "flat 1 abc road_AB2Y8X"
+
+    Returns:
+        A string with concatenated building reference and address info (e.g. "1234_flat 1 abc road_AB2Y8X")
+    """
+    return str(building_reference) + "_" + address_info
+
+
+def enhance_uprn(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Enhances UPRN by filling missing information with known UPRN (if available)
+    or a new property identifier built from the BUILDING_REFERENCE_NUMBER and
+    full adress information.
+
+    Args:
+        df: EPC dataframe
+
+    Returns:
+        EPC dataframe with enhanced UPRN.
+    """
+
+    # Concatenate ADDRESS1, ADDRESS2 and POSTCODE into one variable
+    df["address_info"] = df.apply(
+        lambda x: prepare_address_data(x["ADDRESS1"], x["ADDRESS2"], x["POSTCODE"]),
+        axis=1,
+    )
+
+    # Building a new identifier using the building reference number and address info (including postcode)
+    df["new_property_identifier"] = df.apply(
+        lambda x: concatenate_building_with_address_info(
+            x["BUILDING_REFERENCE_NUMBER"], x["address_info"]
+        ),
+        axis=1,
+    )
+
+    # Creating a mapping between new identifier and existing UPRNs
+    epc_with_uprn = df[~pd.isnull(df["UPRN"])][["UPRN", "new_property_identifier"]]
+    epc_with_uprn.drop_duplicates(["UPRN", "new_property_identifier"], inplace=True)
+
+    mapping = epc_with_uprn.groupby(
+        ["UPRN", "new_property_identifier"], as_index=False
+    ).count()
+    mapping = mapping[["UPRN", "new_property_identifier"]]
+
+    # If a specific new identifier has 2 or more corresponding UPRNs we filter it out from the mapping
+    mapping = mapping[~mapping["new_property_identifier"].duplicated(keep=False)]
+    mapping.set_index("new_property_identifier", inplace=True)
+    mapping = mapping.to_dict()["UPRN"]
+
+    # Create an enhanced UPRN variable from the mapping above
+    df["UPRN_enhanced"] = df["new_property_identifier"].map(mapping)
+
+    # Filling any missing values with existing UPRN values, i.e. for cases when
+    # the new identifier was mapping to multiple different UPRNs
+    df["UPRN_enhanced"].fillna(df["UPRN"], inplace=True)
+
+    # For properties not accounted above, use the new property identifier
+    df["UPRN_enhanced"].fillna(df["new_property_identifier"], inplace=True)
+
+    # Dropping unecessary variables
+    df.drop(columns=["UPRN", "new_property_identifier"], inplace=True)
+
+    # Renaming new UPRN variable
+    df.rename(columns={"UPRN_enhanced": "UPRN"}, inplace=True)
+
+    return df
 
 
 def short_hash(text):
@@ -452,6 +553,7 @@ def get_additional_features(df):
         pandas.DataFrame: Updated dataframe with new features.
     """
 
+    df = enhance_uprn(df)
     df = get_unique_building_id(df)
     df = get_building_entry_feature(df, "UPRN")
 

--- a/asf_core_data/pipeline/preprocessing/feature_engineering.py
+++ b/asf_core_data/pipeline/preprocessing/feature_engineering.py
@@ -113,7 +113,7 @@ def enhance_uprn(df: pd.DataFrame) -> pd.DataFrame:
 
     # Creating a mapping between new identifier and existing UPRNs
     epc_with_uprn = df[~pd.isnull(df["UPRN"])][["UPRN", "new_property_identifier"]]
-    epc_with_uprn.drop_duplicates(["UPRN", "new_property_identifier"], inplace=True)
+    mapping = epc_with_uprn.drop_duplicates(["UPRN", "new_property_identifier"])
 
     # If a specific new identifier has 2 or more corresponding UPRNs we filter it out from the mapping
     mapping = mapping[~mapping["new_property_identifier"].duplicated(keep=False)]

--- a/asf_core_data/pipeline/preprocessing/feature_engineering.py
+++ b/asf_core_data/pipeline/preprocessing/feature_engineering.py
@@ -115,11 +115,6 @@ def enhance_uprn(df: pd.DataFrame) -> pd.DataFrame:
     epc_with_uprn = df[~pd.isnull(df["UPRN"])][["UPRN", "new_property_identifier"]]
     epc_with_uprn.drop_duplicates(["UPRN", "new_property_identifier"], inplace=True)
 
-    mapping = epc_with_uprn.groupby(
-        ["UPRN", "new_property_identifier"], as_index=False
-    ).count()
-    mapping = mapping[["UPRN", "new_property_identifier"]]
-
     # If a specific new identifier has 2 or more corresponding UPRNs we filter it out from the mapping
     mapping = mapping[~mapping["new_property_identifier"].duplicated(keep=False)]
     mapping.set_index("new_property_identifier", inplace=True)


### PR DESCRIPTION
# Description 

This PR fixes:
- #72: prior to this PR, missing `UPRN` was filled with the `BUILDING_REFERENCE_NUMBER` but only for England and Wales, hence `UPRN` had missing values for Scotland. This original enhancement was in script `asf_core_data/getter/epc/epc_data.py`. I removed the enhancement from that script, so that the raw data has missing `UPRN`. We instead now use `BUILDING_REFERENCE_NUMBER` together with address information (`ADDRESS1`, `ADDRESS2` and `POSTCODE`) to enhance `UPRN` during the processing pipeline - changes made to `asf_core_data/pipeline/preprocessing/feature_engineering.py`. Hence, now EPC processed/processed and deduplicated should have no missing `UPRN`.
- #86: I think this has already been fixed by Solomon in asf_daps so no need to change it on your side if loading Scotland data works for you. But in asf_core_data we have problems when loading Scotland data due to column name changes and multiple column headers - so Julia implemented a fix in `load_scotland_data()` in `asf_core_data/getter/epc/epc_data.py` and in `asf_core_data/config/base_config.py`. These changes haven't been committed before, so I'm committing them now.

closes #72
closes #86

# Instructions for Reviewer(s)

## Review

Hey @Jack-Vines and @sqr00t , thanks for reviewing these scripts. Could one of you please double check if the logic looks okay for the changes in `asf_core_data/pipeline/preprocessing/feature_engineering.py`? Thanks a lot!


## Setup
In case you want to run anything (no need to!!!):

- clone this repo: `git clone git@github.com:nestauk/asf_core_data.git`
- checkout to the correct branch: `git checkout 72_fix_property_id_and_epc_loading`
- Run `make install`;
- Run `direnv allow`;
- Activate the conda environment: `conda activate asf_core_data`;
- Run `python asf_core_data/pipeline/preprocessing/preprocess_epc_data.py` (this will load data from S3, so might take some time). If you have raw data in a local folder you can do `python asf_core_data/pipeline/preprocessing/preprocess_epc_data.py --path_to_data "YOUR/LOCAL/PATH/TO/DATA`. Note that, either way, this will only store the processed data locally.
---