### PR TITLE
fix getting processed mcs installations data bug

### DIFF
--- a/asf_core_data/config/base_config.py
+++ b/asf_core_data/config/base_config.py
@@ -956,4 +956,4 @@ preprocessed_historical_installers_date_cols = [
     "solar_assisted_hp_end_date",
 ]
 
-MCS_PROCESSED_FILES_PATH = "/outputs/MCS/"
+MCS_PROCESSED_FILES_PATH = "outputs/MCS/"

--- a/asf_core_data/getters/mcs_getters/get_mcs_installations.py
+++ b/asf_core_data/getters/mcs_getters/get_mcs_installations.py
@@ -10,6 +10,7 @@ from asf_core_data.getters.data_getters import (
     s3,
     load_s3_data,
     get_most_recent_batch_name,
+    logger,
 )
 
 from asf_core_data.config import base_config
@@ -176,10 +177,12 @@ def find_most_recent_mcs_installations_batch(epc_version: str = "none") -> str:
     ]
     try:
         latest_version = max(matches)
-        print(f"Latest version available on S3: <{latest_version}>")
+        logger.info(f"Latest version available on S3: <{latest_version}>")
         return latest_version
     except ValueError:
-        print(f"No files found in {bucket} bucket for epc_version='{epc_version}'")
+        logger.error(
+            f"ValueError: No files found in {bucket} bucket for epc_version='{epc_version}'"
+        )
 
 
 def get_processed_installations_data_by_batch(
@@ -208,7 +211,7 @@ def get_processed_installations_data_by_batch(
         file_prefix = keyword_to_path_dict[epc_version]
         # note that [1:] removes the first "/" in the file path
         processed_installations_file_path = file_prefix.format(batch_date)[1:]
-    print(f"Loading <{processed_installations_file_path}> from S3")
+    logger.info(f"Loading <{processed_installations_file_path}> from S3")
 
     return load_s3_data(
         bucket_name=bucket_name, file_name=processed_installations_file_path

--- a/asf_core_data/getters/mcs_getters/get_mcs_installations.py
+++ b/asf_core_data/getters/mcs_getters/get_mcs_installations.py
@@ -206,8 +206,8 @@ def get_processed_installations_data_by_batch(
         )
     else:
         file_prefix = keyword_to_path_dict[epc_version]
-       # note that [1:] removes the first "/" in the file path
-        processed_installations_file_path = file_prefix.format(batch_date)[1:] 
+        # note that [1:] removes the first "/" in the file path
+        processed_installations_file_path = file_prefix.format(batch_date)[1:]
     print(f"Loading <{processed_installations_file_path}> from S3")
 
     return load_s3_data(

--- a/asf_core_data/getters/mcs_getters/get_mcs_installations.py
+++ b/asf_core_data/getters/mcs_getters/get_mcs_installations.py
@@ -184,15 +184,15 @@ def find_most_recent_mcs_installations_batch(epc_version: str = "none"):
 
 
 def get_processed_installations_data_by_batch(
-    processed_installations_batch: str = "newest", epc_version: str = "none"
+    batch_date: str = "newest", epc_version: str = "none"
 ) -> pd.DataFrame:
     """
     Get a specified version of the processed MCS installation (+ EPC) data (both domestic and non-domestic)
     from S3 (either just MCS or MCS merged with EPC) using batch date.
 
     Args:
-        processed_installations_batch: Date of desired batch in YYMMDD format. Defaults to "newest" which searches
-        S3 for latest batch.
+        batch_date: Date of desired batch of processed MCS installation data in YYMMDD format. Defaults to "newest"
+        which searches S3 for latest batch.
         epc_version: One of "none", "full", or "most_relevant".
             - "none" returns just installation data
             - "full" returns installation data with each property's entire EPC history attached
@@ -201,17 +201,15 @@ def get_processed_installations_data_by_batch(
     Returns:
         DataFrame: Processed MCS installations data (either merged or not merged with EPC)
     """
-    if processed_installations_batch == "newest":
-        processed_installations_file_name = find_most_recent_mcs_installations_batch(
+    if batch_date == "newest":
+        processed_installations_file_path = find_most_recent_mcs_installations_batch(
             epc_version=epc_version
         )
     else:
         file_prefix = keyword_to_path_dict[epc_version]
-        processed_installations_file_name = file_prefix.format(
-            processed_installations_batch
-        )[1:]
-    print(f"Loading <{processed_installations_file_name}> from S3")
+        processed_installations_file_path = file_prefix.format(batch_date)[1:]
+    print(f"Loading <{processed_installations_file_path}> from S3")
 
     return load_s3_data(
-        bucket_name=base_config.BUCKET_NAME, file_name=processed_installations_file_name
+        bucket_name=base_config.BUCKET_NAME, file_name=processed_installations_file_path
     )

--- a/asf_core_data/getters/mcs_getters/get_mcs_installations.py
+++ b/asf_core_data/getters/mcs_getters/get_mcs_installations.py
@@ -154,7 +154,7 @@ def get_processed_installations_data(
     )
 
 
-def find_most_recent_mcs_installations_batch(epc_version: str = "none"):
+def find_most_recent_mcs_installations_batch(epc_version: str = "none") -> str:
     """
     Finds most recent batch of MCS installations data, joined with EPC data in specified format if specified.
     Args:
@@ -207,7 +207,8 @@ def get_processed_installations_data_by_batch(
         )
     else:
         file_prefix = keyword_to_path_dict[epc_version]
-        processed_installations_file_path = file_prefix.format(batch_date)[1:]
+       # note that [1:] removes the first "/" in the file path
+        processed_installations_file_path = file_prefix.format(batch_date)[1:] 
     print(f"Loading <{processed_installations_file_path}> from S3")
 
     return load_s3_data(

--- a/asf_core_data/getters/mcs_getters/get_mcs_installations.py
+++ b/asf_core_data/getters/mcs_getters/get_mcs_installations.py
@@ -52,7 +52,7 @@ def get_raw_installations_data(
 
     if refresh or not os.path.exists(local_path):
         hps = load_s3_data(
-            base_config.BUCKET_NAME, base_config.INSTALLATIONS_RAW_S3_PATH, usecols=None
+            bucket_name, base_config.INSTALLATIONS_RAW_S3_PATH, usecols=None
         )
     else:
         hps = pd.read_excel(local_path)
@@ -94,15 +94,13 @@ def get_most_recent_raw_historical_installations_data() -> pd.DataFrame:
     Returns:
         The most recent version of the raw historical installations data from MCS.
     """
-
-    bucket = base_config.BUCKET_NAME
     path = base_config.MCS_HISTORICAL_DATA_INPUTS_PATH
     most_recent_file_name = get_most_recent_batch_name(
-        bucket=bucket, s3_folder_path=path, filter_keep_keywords=["installation"]
+        bucket=bucket_name, s3_folder_path=path, filter_keep_keywords=["installation"]
     )
 
     return load_s3_data(
-        base_config.BUCKET_NAME,
+        bucket_name,
         most_recent_file_name,
         dtype=base_config.raw_historical_installations_dtypes,
     )
@@ -123,7 +121,7 @@ def get_raw_historical_installations_data(
     """
 
     return load_s3_data(
-        base_config.BUCKET_NAME,
+        bucket_name,
         os.path.join(
             base_config.MCS_HISTORICAL_DATA_INPUTS_PATH,
             raw_historical_installations_file_name,
@@ -146,7 +144,7 @@ def get_processed_installations_data(
     """
 
     return load_s3_data(
-        base_config.BUCKET_NAME,
+        bucket_name,
         os.path.join(
             base_config.MCS_PROCESSED_FILES_PATH,
             processed_installations_file_name,
@@ -167,8 +165,9 @@ def find_most_recent_mcs_installations_batch(epc_version: str = "none"):
         str: Filename of most recent MCS installations (+ EPC) data.
     """
     bucket = s3.Bucket(bucket_name)
-    folder = mcs_processed_dir
-    file_list = [object.key for object in bucket.objects.filter(Prefix=folder)]
+    file_list = [
+        object.key for object in bucket.objects.filter(Prefix=mcs_processed_dir)
+    ]
     file_prefix = keyword_to_path_dict[epc_version].split("{")[0]
     matches = [
         filename
@@ -211,5 +210,5 @@ def get_processed_installations_data_by_batch(
     print(f"Loading <{processed_installations_file_path}> from S3")
 
     return load_s3_data(
-        bucket_name=base_config.BUCKET_NAME, file_name=processed_installations_file_path
+        bucket_name=bucket_name, file_name=processed_installations_file_path
     )

--- a/asf_core_data/getters/mcs_getters/get_mcs_installations.py
+++ b/asf_core_data/getters/mcs_getters/get_mcs_installations.py
@@ -4,10 +4,29 @@ with correct dtypes."""
 
 import pandas as pd
 import os
+import re
 
-from asf_core_data.getters.data_getters import load_s3_data, get_most_recent_batch_name
+from asf_core_data.getters.data_getters import (
+    s3,
+    load_s3_data,
+    get_most_recent_batch_name,
+)
 
 from asf_core_data.config import base_config
+
+bucket_name = base_config.BUCKET_NAME
+mcs_processed_dir = base_config.MCS_PROCESSED_FILES_PATH
+mcs_installations_path = base_config.MCS_INSTALLATIONS_PATH
+mcs_installations_epc_full_path = base_config.MCS_INSTALLATIONS_EPC_FULL_PATH
+mcs_installations_epc_most_relevant_path = (
+    base_config.MCS_INSTALLATIONS_EPC_MOST_RELEVANT_PATH
+)
+
+keyword_to_path_dict = {
+    "none": mcs_installations_path,
+    "full": mcs_installations_epc_full_path,
+    "most_relevant": mcs_installations_epc_most_relevant_path,
+}
 
 
 def get_raw_installations_data(
@@ -97,7 +116,7 @@ def get_raw_historical_installations_data(
     for S3 bucket.
 
     Args:
-        raw_historical_mcs_installations_file_name: name of file in S3 bucket, raw_historical_installations_YYYYMMDD.xlsx
+        raw_historical_installations_file_name: name of file in S3 bucket, raw_historical_installations_YYYYMMDD.xlsx
         where YYYY/MM/DD is the date MCS shared the file in the Data Dumps Google Drive folder.
     Returns:
         Raw historical installation data
@@ -118,7 +137,7 @@ def get_processed_installations_data(
 ) -> pd.DataFrame:
     """
     Get a specified version of the processed MCS installation data (both domestic and non-domestic)
-    from S3 (either just MCS or MCS merged with EPC).
+    from S3 (either just MCS or MCS merged with EPC) using filename.
 
     Args:
         processed_installations_file_name: name of processed file
@@ -132,4 +151,67 @@ def get_processed_installations_data(
             base_config.MCS_PROCESSED_FILES_PATH,
             processed_installations_file_name,
         ),
+    )
+
+
+def find_most_recent_mcs_installations_batch(epc_version: str = "none"):
+    """
+    Finds most recent batch of MCS installations data, joined with EPC data in specified format if specified.
+    Args:
+        epc_version: One of "none", "full", or "most_relevant".
+            - "none" returns just installation data
+            - "full" returns installation data with each property's entire EPC history attached
+            - "most_relevant" selects the most recent EPC from before the HP installation if one exists or the earliest
+            EPC from after the HP installation otherwise. Defaults to "none".
+    Returns:
+        str: Filename of most recent MCS installations (+ EPC) data.
+    """
+    bucket = s3.Bucket(bucket_name)
+    folder = mcs_processed_dir
+    file_list = [object.key for object in bucket.objects.filter(Prefix=folder)]
+    file_prefix = keyword_to_path_dict[epc_version].split("{")[0]
+    matches = [
+        filename
+        for filename in file_list
+        if ("/" + re.split("[0-9]", filename)[0] == file_prefix)
+    ]
+    try:
+        latest_version = max(matches)
+        print(f"Latest version available on S3: <{latest_version}>")
+        return latest_version
+    except ValueError:
+        print(f"No files found in {bucket} bucket for epc_version='{epc_version}'")
+
+
+def get_processed_installations_data_by_batch(
+    processed_installations_batch: str = "newest", epc_version: str = "none"
+) -> pd.DataFrame:
+    """
+    Get a specified version of the processed MCS installation (+ EPC) data (both domestic and non-domestic)
+    from S3 (either just MCS or MCS merged with EPC) using batch date.
+
+    Args:
+        processed_installations_batch: Date of desired batch in YYMMDD format. Defaults to "newest" which searches
+        S3 for latest batch.
+        epc_version: One of "none", "full", or "most_relevant".
+            - "none" returns just installation data
+            - "full" returns installation data with each property's entire EPC history attached
+            - "most_relevant" selects the most recent EPC from before the HP installation if one exists or the earliest
+            EPC from after the HP installation otherwise. Defaults to "none".
+    Returns:
+        DataFrame: Processed MCS installations data (either merged or not merged with EPC)
+    """
+    if processed_installations_batch == "newest":
+        processed_installations_file_name = find_most_recent_mcs_installations_batch(
+            epc_version=epc_version
+        )
+    else:
+        file_prefix = keyword_to_path_dict[epc_version]
+        processed_installations_file_name = file_prefix.format(
+            processed_installations_batch
+        )[1:]
+    print(f"Loading <{processed_installations_file_name}> from S3")
+
+    return load_s3_data(
+        bucket_name=base_config.BUCKET_NAME, file_name=processed_installations_file_name
     )


### PR DESCRIPTION
Fixes #100 

Changes:
- correct MCS_PROCESSED_FILES_PATH in base_config.py
- add new function to getters to get processed MCS installation data from S3 from a specific date.
- add new function to find most recent processed MCS installations data on S3 for a specified join with EPC data.
- update docstring for get_raw_historical_installations_data to match function param name

During review, please could you:
- review new functions to ensure they make sense and work
- check that changed MCS_PROCESSED_FILES_PATH does not cause issues elsewhere in code. I have checked core repo and believe there are only 2 uses which work but good to double check

---

Checklist:

- [y ] I have refactored my code out from `notebooks/`
- [y] I have checked the code runs
- [y ] I have tested the code
- [y ] I have run `pre-commit` and addressed any issues not automatically fixed
- [y ] I have merged any new changes from `dev`
- [y ] I have documented the code
  - [y ] Major functions have docstrings
  - [n/a ] Appropriate information has been added to `README`s
- [y ] I have explained the feature in this PR or (better) in `output/reports/`
- [y ] I have requested a code review
