### PR TITLE
updating README after new batch of EPC and MCS data - Q2 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ASF Core Data <a name="core_data_overview"></a>
 
-Last updated: September 2023 by Sofia Pinto
+Last updated: October 2023 by Sofia Pinto
 
 ## Overview <a name="overview"></a>
 
@@ -40,12 +40,12 @@ This repository is the foundation for many projects in our work on sustainabilit
 
 Generally, both the EPC and MCS data will be updated every three months. Release dates can vary, as we are not responsible for the release of the raw data.
 
-| Dataset                     | Content       | Last updated    | Includes data up to |
-| --------------------------- | ------------- | --------------- | ------------------- |
-| EPC England/Wales           | up to Q1 2023 | 25 May 2023     | 30 April 2023       |
-| EPC Scotland                | up to Q1 2023 | 13 June 2023    | 30 April 2023       |
-| MCS Heat Pump Installations | up to Q1 2023 | 19 April 2023   | 31 March 2023       |
-| MCS HP Installer Data       | up to Q4 2022 | 7 February 2023 | January 2023        |
+| Dataset                     | Content       | Last updated | Includes data up to |
+| --------------------------- | ------------- | ------------ | ------------------- |
+| EPC England/Wales           | up to Q2 2023 | 0ctober 2023 | 31 July 2023        |
+| EPC Scotland                | up to Q2 2023 | October 2023 | 30 June 2023        |
+| MCS Heat Pump Installations | up to Q2 2023 | October 2023 | 30 June 2023        |
+| MCS HP Installer Data       | up to Q2 2023 | October 2023 | 30 June 2023        |
 
 <a href="#top">[back to top]</a>
 


### PR DESCRIPTION
# Description

This pull request updates repo `README.md` after new quarter data has been added.


- updated MCS installer and installation data up to Q2 2023: up to 30th of **_June_** 2023
- updated EPC data up to Q2 2023: 
    - England and Wales: up to 31st of **_July_** 2023 - notice the extra month for this one (EPC data for England and Wales is now made available every month, instead of every quarter)
    - Scotland: up to 30th of **_June_** 2023

Closes #99 


# Instructions for reviewers

Hey @helloaidank @crispy-wonton 

No need to review anything on this PR. Only change is: `README.md` has been updated to reflect the data refresh. Just tagging you for you to be aware of the data update.

---

Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [ ] I have checked the code runs
- [ ] I have tested the code
- [ ] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [x] I have documented the code
  - [ ] Major functions have docstrings
  - [x] Appropriate information has been added to `README`s
- [ ] I have explained the feature in this PR or (better) in `output/reports/`
- [ ] I have requested a code review
